### PR TITLE
chore(maven): improve configuration

### DIFF
--- a/artifacts-model-dependencies/pom.xml
+++ b/artifacts-model-dependencies/pom.xml
@@ -10,16 +10,8 @@
   <packaging>pom</packaging>
   <name>Bonita Artifacts Model Dependencies</name>
   <description>This module is the Bill of Material of the Artifacts Model modules</description>
-  <scm>
-    <connection>scm:git:git@github.com:bonitasoft/bonita-artifacts-model.git</connection>
-    <developerConnection>scm:git:git@github.com:bonitasoft/bonita-artifacts-model.git</developerConnection>
-    <tag>HEAD</tag>
-    <url>https://github.com/bonitasoft/bonita-artifacts-model</url>
-  </scm>
   <properties>
-    <eclipse.formatter.file>${project.parent.basedir}/formatter.xml</eclipse.formatter.file>
-    <eclipse.importorder.file>${project.parent.basedir}/eclipse.importorder</eclipse.importorder.file>
-    <header.file>${project.parent.basedir}/header.txt</header.file>
+    <maven.deploy.skip>false</maven.deploy.skip>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -66,17 +58,6 @@
             <dependencyManagement>interpolate</dependencyManagement>
           </pomElements>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <configuration>
-          <skip>false</skip>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/business-archive/pom.xml
+++ b/business-archive/pom.xml
@@ -9,13 +9,8 @@
   <artifactId>bonita-business-archive</artifactId>
   <name>Bonita Business Archive</name>
   <description>This module is used to write/read the Bonita Business Archive file format.</description>
-  <scm>
-    <url>https://github.com/bonitasoft/bonita-artifacts-model</url>
-  </scm>
   <properties>
-    <eclipse.formatter.file>${project.parent.basedir}/formatter.xml</eclipse.formatter.file>
-    <eclipse.importorder.file>${project.parent.basedir}/eclipse.importorder</eclipse.importorder.file>
-    <header.file>${project.parent.basedir}/header.txt</header.file>
+    <maven.deploy.skip>false</maven.deploy.skip>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -83,19 +78,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <configuration>
-          <skip>false</skip>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/coverage-report/pom.xml
+++ b/coverage-report/pom.xml
@@ -10,9 +10,7 @@
   <packaging>pom</packaging>
   <name>Bonita Artifacts Model Coverage Report</name>
   <properties>
-    <eclipse.formatter.file>${project.parent.basedir}/formatter.xml</eclipse.formatter.file>
-    <eclipse.importorder.file>${project.parent.basedir}/eclipse.importorder</eclipse.importorder.file>
-    <header.file>${project.parent.basedir}/header.txt</header.file>
+    <maven.deploy.skip>true</maven.deploy.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/form-mapping-model/pom.xml
+++ b/form-mapping-model/pom.xml
@@ -9,13 +9,8 @@
   <artifactId>bonita-form-mapping-model</artifactId>
   <name>Bonita Form Mapping Model</name>
   <description>This module defines the Bonita Form Mapping Model.</description>
-  <scm>
-    <url>https://github.com/bonitasoft/bonita-artifacts-model</url>
-  </scm>
   <properties>
-    <eclipse.formatter.file>${project.parent.basedir}/formatter.xml</eclipse.formatter.file>
-    <eclipse.importorder.file>${project.parent.basedir}/eclipse.importorder</eclipse.importorder.file>
-    <header.file>${project.parent.basedir}/header.txt</header.file>
+    <maven.deploy.skip>false</maven.deploy.skip>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -94,17 +89,6 @@
             </configuration>
           </execution>
         </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <configuration>
-          <skip>false</skip>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" child.project.url.inherit.append.path="false" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.bonitasoft.engine</groupId>
   <artifactId>bonita-artifacts-model-parent</artifactId>
@@ -30,7 +30,7 @@
     <module>artifacts-model-dependencies</module>
     <module>coverage-report</module>
   </modules>
-  <scm>
+  <scm child.scm.connection.inherit.append.path="false" child.scm.developerConnection.inherit.append.path="false" child.scm.url.inherit.append.path="false">
     <connection>scm:git:git@github.com:bonitasoft/bonita-artifacts-model.git</connection>
     <developerConnection>scm:git:git@github.com:bonitasoft/bonita-artifacts-model.git</developerConnection>
     <tag>HEAD</tag>
@@ -82,9 +82,9 @@
     <groovy-maven-plugin.version>2.1.1</groovy-maven-plugin.version>
     <groovy.version>3.0.18</groovy.version>
     <!-- Spotless resources location -->
-    <eclipse.formatter.file>${project.basedir}/formatter.xml</eclipse.formatter.file>
-    <eclipse.importorder.file>${project.basedir}/eclipse.importorder</eclipse.importorder.file>
-    <header.file>${project.basedir}/header.txt</header.file>
+    <eclipse.formatter.file>${maven.multiModuleProjectDirectory}/formatter.xml</eclipse.formatter.file>
+    <eclipse.importorder.file>${maven.multiModuleProjectDirectory}/eclipse.importorder</eclipse.importorder.file>
+    <header.file>${maven.multiModuleProjectDirectory}/header.txt</header.file>
     <!-- Sonar -->
     <sonar.projectKey>${sonar.organization}_bonita-artifacts-model</sonar.projectKey>
     <sonar.moduleKey>${project.groupId}:${project.artifactId}</sonar.moduleKey>
@@ -92,6 +92,7 @@
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     <sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/../coverage-report/target/site/jacoco-aggregate/jacoco.xml,
 			${project.basedir}/coverage-report/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
+    <maven.deploy.skip>true</maven.deploy.skip>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -256,9 +257,6 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-deploy-plugin</artifactId>
           <version>${maven-deploy-plugin.version}</version>
-          <configuration>
-            <skip>true</skip>
-          </configuration>
         </plugin>
         <plugin>
           <groupId>org.sonarsource.scanner.maven</groupId>
@@ -276,6 +274,7 @@
             <keepStagingRepositoryOnCloseRuleFailure>true</keepStagingRepositoryOnCloseRuleFailure>
             <serverId>ossrh</serverId>
             <nexusUrl>https://oss.sonatype.org</nexusUrl>
+            <skipNexusStagingDeployMojo>${maven.deploy.skip}</skipNexusStagingDeployMojo>
           </configuration>
         </plugin>
         <plugin>
@@ -432,6 +431,10 @@
             <phase>clean</phase>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/process-definition-model/pom.xml
+++ b/process-definition-model/pom.xml
@@ -9,13 +9,8 @@
   <artifactId>bonita-process-definition-model</artifactId>
   <name>Bonita Process Definition Model</name>
   <description>This module defines the Bonita Process Definition Model.</description>
-  <scm>
-    <url>https://github.com/bonitasoft/bonita-artifacts-model</url>
-  </scm>
   <properties>
-    <eclipse.formatter.file>${project.parent.basedir}/formatter.xml</eclipse.formatter.file>
-    <eclipse.importorder.file>${project.parent.basedir}/eclipse.importorder</eclipse.importorder.file>
-    <header.file>${project.parent.basedir}/header.txt</header.file>
+    <maven.deploy.skip>false</maven.deploy.skip>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -80,19 +75,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <configuration>
-          <skip>false</skip>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
-      </plugin>
-    </plugins>
-  </build>
 </project>


### PR DESCRIPTION
* Use `child.project.url.inherit.append.path="false` and `child.scm.connection.inherit.append.path="false"
child.scm.developerConnection.inherit.append.path="false" child.scm.url.inherit.append.path="false"` to have proper child module information for `url` and `scm.url`

* Use `maven.deploy.skip` property to configure modules to be deployed.
* Use `maven.multiModuleProjectDirectory` property to locate the formatter resources