### PR TITLE
fix(bdm): Do not set a default productVersion

### DIFF
--- a/bdm-access-control-model/src/main/java/com/bonitasoft/engine/bdm/accesscontrol/model/BusinessObjectAccessControlModel.java
+++ b/bdm-access-control-model/src/main/java/com/bonitasoft/engine/bdm/accesscontrol/model/BusinessObjectAccessControlModel.java
@@ -13,15 +13,9 @@
  **/
 package com.bonitasoft.engine.bdm.accesscontrol.model;
 
-import static org.bonitasoft.engine.bdm.model.BusinessObjectModel.INFO_PROPERTIES_RESOURCE;
-import static org.bonitasoft.engine.bdm.model.BusinessObjectModel.VERSION_PROPERTY_KEY;
-
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
-import java.util.Properties;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -29,10 +23,6 @@ import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
-
-import org.glassfish.hk2.osgiresourcelocator.ResourceFinder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * @author Adrien Lachambre, Emmanuel Duchastenier
@@ -43,25 +33,6 @@ import org.slf4j.LoggerFactory;
 public class BusinessObjectAccessControlModel {
 
     public static final String CURRENT_MODEL_VERSION = "1.0";
-
-    public static final String CURRENT_PRODUCT_VERSION;
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(BusinessObjectAccessControlModel.class);
-
-    static {
-        final Properties info = new Properties();
-        try {
-            var infoProperties = Optional.ofNullable(ResourceFinder.findEntry(INFO_PROPERTIES_RESOURCE))
-                    .orElseGet(() -> BusinessObjectAccessControlModel.class.getResource(INFO_PROPERTIES_RESOURCE));
-            if (infoProperties != null) {
-                info.load(infoProperties.openStream());
-            }
-        } catch (final IOException e) {
-            LOGGER.error("Failed to retrieve product version", e);
-        }
-        final String version = info.getProperty(VERSION_PROPERTY_KEY);
-        CURRENT_PRODUCT_VERSION = version == null || version.isBlank() ? null : version;
-    }
 
     @XmlAttribute(name = "modelVersion")
     private String modelVersion;

--- a/business-object-model/src/main/java/org/bonitasoft/engine/bdm/BusinessObjectModelConverter.java
+++ b/business-object-model/src/main/java/org/bonitasoft/engine/bdm/BusinessObjectModelConverter.java
@@ -66,10 +66,6 @@ public class BusinessObjectModelConverter {
         if (modelVersion == null || modelVersion.isEmpty()) {
             bom.setModelVersion(BusinessObjectModel.CURRENT_MODEL_VERSION);
         }
-        final String productVersion = bom.getProductVersion();
-        if (productVersion == null || productVersion.isEmpty()) {
-            bom.setProductVersion(BusinessObjectModel.CURRENT_PRODUCT_VERSION);
-        }
         return marshallObjectToXML(bom);
     }
 

--- a/business-object-model/src/main/java/org/bonitasoft/engine/bdm/model/BusinessObjectModel.java
+++ b/business-object-model/src/main/java/org/bonitasoft/engine/bdm/model/BusinessObjectModel.java
@@ -13,13 +13,10 @@
  **/
 package org.bonitasoft.engine.bdm.model;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
-import java.util.Properties;
 import java.util.Set;
 import java.util.StringJoiner;
 
@@ -30,10 +27,6 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 
-import org.glassfish.hk2.osgiresourcelocator.ResourceFinder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
  * @author Matthieu Chaffotte
  */
@@ -42,26 +35,6 @@ import org.slf4j.LoggerFactory;
 public class BusinessObjectModel {
 
     public static final String CURRENT_MODEL_VERSION = "1.0";
-    public static final String CURRENT_PRODUCT_VERSION;
-    public static final String INFO_PROPERTIES_RESOURCE = "/info.properties";
-    public static final String VERSION_PROPERTY_KEY = "version";
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(BusinessObjectModel.class);
-
-    static {
-        final Properties info = new Properties();
-        try {
-            var infoProperties = Optional.ofNullable(ResourceFinder.findEntry(INFO_PROPERTIES_RESOURCE))
-                    .orElseGet(() -> BusinessObjectModel.class.getResource(INFO_PROPERTIES_RESOURCE));
-            if (infoProperties != null) {
-                info.load(infoProperties.openStream());
-            }
-        } catch (final IOException e) {
-            LOGGER.error("Failed to retrieve product version", e);
-        }
-        final String version = info.getProperty(VERSION_PROPERTY_KEY);
-        CURRENT_PRODUCT_VERSION = version == null || version.isBlank() ? null : version;
-    }
 
     @XmlElementWrapper(name = "businessObjects", required = true)
     @XmlElement(name = "businessObject", required = true)

--- a/business-object-model/src/main/resources/info.properties
+++ b/business-object-model/src/main/resources/info.properties
@@ -1,1 +1,0 @@
-version=${project.version}

--- a/business-object-model/src/test/java/org/bonitasoft/engine/bdm/BusinessObjectModelConverterTest.java
+++ b/business-object-model/src/test/java/org/bonitasoft/engine/bdm/BusinessObjectModelConverterTest.java
@@ -150,7 +150,7 @@ class BusinessObjectModelConverterTest {
         final BusinessObjectModel unmarshalledBom = convertor.unmarshall(convertor.marshall(bom));
 
         assertThat(unmarshalledBom.getModelVersion()).isEqualTo(BusinessObjectModel.CURRENT_MODEL_VERSION);
-        assertThat(bom.getProductVersion()).isNotNull().isNotEmpty();
+        assertThat(bom.getProductVersion()).isNull();
     }
 
     @Test


### PR DESCRIPTION
The `productVersion` attribute is not relevant.

This attribute will now be used at runtime when generating the java jar to identify the productVersion used for generation