### PR TITLE
feat(bar): Possibility to indicate a jarless Business Archive (.bar)

### DIFF
--- a/business-archive/src/main/java/org/bonitasoft/engine/bpm/bar/BusinessArchive.java
+++ b/business-archive/src/main/java/org/bonitasoft/engine/bpm/bar/BusinessArchive.java
@@ -37,6 +37,8 @@ public class BusinessArchive implements Serializable {
 
     private static final long serialVersionUID = -6410347766671025202L;
 
+    private static final String JAR_LESS_MARKER_RESOURCE_PATH = ".jarless";
+
     private final Map<String, byte[]> resources = new HashMap<>();
 
     private DesignProcessDefinition processDefinition;
@@ -46,6 +48,22 @@ public class BusinessArchive implements Serializable {
     private FormMappingModel formMappingModel = new FormMappingModel();
 
     private ActorMapping actorMapping = null;
+
+    /**
+     * Test whether this is BusinessArchive file contains the dependency jars.
+     * 
+     * @return true when it contains dependency jars, false when jar less
+     */
+    public boolean hasDependencyJars() {
+        return !resources.containsKey(JAR_LESS_MARKER_RESOURCE_PATH);
+    }
+
+    /**
+     * Tag this BusinessArchive file to indicate it does not contain the dependency jars.
+     */
+    public void tagWithoutDependencyJars() {
+        resources.put(JAR_LESS_MARKER_RESOURCE_PATH, new byte[] {});
+    }
 
     /*
      * Retrieves the actorMapping from the bar

--- a/business-archive/src/main/java/org/bonitasoft/engine/bpm/bar/BusinessArchiveBuilder.java
+++ b/business-archive/src/main/java/org/bonitasoft/engine/bpm/bar/BusinessArchiveBuilder.java
@@ -56,6 +56,16 @@ public class BusinessArchiveBuilder {
     }
 
     /**
+     * Indicate the {@link BusinessArchive} that is currently build Tag will not contain the dependency jars.
+     * 
+     * @return the same {@link BusinessArchiveBuilder} in order to chain calls
+     */
+    public BusinessArchiveBuilder withoutDependencyJars() {
+        entity.tagWithoutDependencyJars();
+        return this;
+    }
+
+    /**
      * Set the process definition of the {@link BusinessArchive} that is currently build
      * <p> {@link DesignProcessDefinition} can be constructed using
      * {@link org.bonitasoft.engine.bpm.process.impl.ProcessDefinitionBuilder}

--- a/business-archive/src/test/java/org/bonitasoft/engine/bpm/bar/BusinessArchiveBuilderTest.java
+++ b/business-archive/src/test/java/org/bonitasoft/engine/bpm/bar/BusinessArchiveBuilderTest.java
@@ -32,18 +32,18 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class BusinessArchiveBuilderTest {
 
     @Spy
-    BusinessArchiveBuilder archive;
+    BusinessArchiveBuilder builder;
 
     @BeforeEach
-    public void initialization() {
-        archive.createNewBusinessArchive();
+    void initialization() {
+        builder.createNewBusinessArchive();
     }
 
     @Test
     void addFormMappingsShouldAddFileWithProperName() throws Exception {
         final FormMappingModel inputModel = new FormMappingModel();
         // when:
-        final BusinessArchive archive = new BusinessArchiveBuilder().createNewBusinessArchive()
+        final BusinessArchive archive = builder
                 .setProcessDefinition(new ProcessDefinitionBuilder().createNewInstance("proc", "1").done())
                 .setFormMappings(inputModel).done();
 
@@ -75,7 +75,7 @@ class BusinessArchiveBuilderTest {
                 + "</actorMapping>"
                 + "</actorMappings:actorMappings>";
         byte[] xmlContent = xmlString.getBytes();
-        final ActorMapping actorMapping = archive.setActorMapping(xmlContent).getActorMapping();
+        final ActorMapping actorMapping = builder.setActorMapping(xmlContent).getActorMapping();
 
         assertThat(actorMapping).isNotNull();
         assertThat(actorMapping.getActors()).hasSize(1);
@@ -96,7 +96,7 @@ class BusinessArchiveBuilderTest {
             assertThat(membership.getRole()).isEqualTo("dev");
         }
 
-        verify(archive, times(1)).setActorMapping(actorMapping);
+        verify(builder, times(1)).setActorMapping(actorMapping);
 
         final String generatedXMLActorMapping = new String(new ActorMappingMarshaller().serializeToXML(actorMapping));
         assertThat(generatedXMLActorMapping).doesNotContain("ns2")
@@ -106,7 +106,7 @@ class BusinessArchiveBuilderTest {
     @Test
     void ensure_jarlessBar_has_marker() throws Exception {
         // when:
-        final BusinessArchive archive = new BusinessArchiveBuilder().createNewBusinessArchive()
+        final BusinessArchive archive = builder
                 .setProcessDefinition(new ProcessDefinitionBuilder().createNewInstance("proc", "1").done())
                 .withoutDependencyJars().done();
 
@@ -118,7 +118,7 @@ class BusinessArchiveBuilderTest {
     @Test
     void ensure_normalBar_is_not_jarless() throws Exception {
         // when:
-        final BusinessArchive archive = new BusinessArchiveBuilder().createNewBusinessArchive()
+        final BusinessArchive archive = builder
                 .setProcessDefinition(new ProcessDefinitionBuilder().createNewInstance("proc", "1").done())
                 .done();
 

--- a/business-archive/src/test/java/org/bonitasoft/engine/bpm/bar/BusinessArchiveBuilderTest.java
+++ b/business-archive/src/test/java/org/bonitasoft/engine/bpm/bar/BusinessArchiveBuilderTest.java
@@ -102,4 +102,28 @@ class BusinessArchiveBuilderTest {
         assertThat(generatedXMLActorMapping).doesNotContain("ns2")
                 .contains("actorMappings:");
     }
+
+    @Test
+    void ensure_jarlessBar_has_marker() throws Exception {
+        // when:
+        final BusinessArchive archive = new BusinessArchiveBuilder().createNewBusinessArchive()
+                .setProcessDefinition(new ProcessDefinitionBuilder().createNewInstance("proc", "1").done())
+                .withoutDependencyJars().done();
+
+        // then:
+        assertThat(archive.hasDependencyJars()).isFalse();
+        assertThat(archive.getResource(".jarless")).isEmpty();
+    }
+
+    @Test
+    void ensure_normalBar_is_not_jarless() throws Exception {
+        // when:
+        final BusinessArchive archive = new BusinessArchiveBuilder().createNewBusinessArchive()
+                .setProcessDefinition(new ProcessDefinitionBuilder().createNewInstance("proc", "1").done())
+                .done();
+
+        // then:
+        assertThat(archive.hasDependencyJars()).isTrue();
+        assertThat(archive.getResource(".jarless")).isNull();
+    }
 }


### PR DESCRIPTION
A .jarless empty file is the marker for a bar file which does not contain the dependency jars. (to be used for SCA only)

Relates to [BPM-406](https://bonitasoft.atlassian.net/browse/BPM-406)

[BPM-406]: https://bonitasoft.atlassian.net/browse/BPM-406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ