### PR TITLE
fix(jarless_bar): add BAR contributor for .jarless marker

### DIFF
--- a/business-archive/src/main/java/org/bonitasoft/engine/bpm/bar/BusinessArchive.java
+++ b/business-archive/src/main/java/org/bonitasoft/engine/bpm/bar/BusinessArchive.java
@@ -37,8 +37,6 @@ public class BusinessArchive implements Serializable {
 
     private static final long serialVersionUID = -6410347766671025202L;
 
-    private static final String JAR_LESS_MARKER_RESOURCE_PATH = ".jarless";
-
     private final Map<String, byte[]> resources = new HashMap<>();
 
     private DesignProcessDefinition processDefinition;
@@ -55,14 +53,14 @@ public class BusinessArchive implements Serializable {
      * @return true when it contains dependency jars, false when jar less
      */
     public boolean hasDependencyJars() {
-        return !resources.containsKey(JAR_LESS_MARKER_RESOURCE_PATH);
+        return !resources.containsKey(JarlessMarkerContribution.JAR_LESS_MARKER_RESOURCE_PATH);
     }
 
     /**
      * Tag this BusinessArchive file to indicate it does not contain the dependency jars.
      */
     public void tagWithoutDependencyJars() {
-        resources.put(JAR_LESS_MARKER_RESOURCE_PATH, new byte[] {});
+        resources.put(JarlessMarkerContribution.JAR_LESS_MARKER_RESOURCE_PATH, new byte[] {});
     }
 
     /*

--- a/business-archive/src/main/java/org/bonitasoft/engine/bpm/bar/BusinessArchive.java
+++ b/business-archive/src/main/java/org/bonitasoft/engine/bpm/bar/BusinessArchive.java
@@ -47,20 +47,22 @@ public class BusinessArchive implements Serializable {
 
     private ActorMapping actorMapping = null;
 
+    private boolean hasDependencyJars = true;
+
     /**
      * Test whether this is BusinessArchive file contains the dependency jars.
      * 
      * @return true when it contains dependency jars, false when jar less
      */
     public boolean hasDependencyJars() {
-        return !resources.containsKey(JarlessMarkerContribution.JAR_LESS_MARKER_RESOURCE_PATH);
+        return hasDependencyJars;
     }
 
     /**
      * Tag this BusinessArchive file to indicate it does not contain the dependency jars.
      */
     public void tagWithoutDependencyJars() {
-        resources.put(JarlessMarkerContribution.JAR_LESS_MARKER_RESOURCE_PATH, new byte[] {});
+        hasDependencyJars = false;
     }
 
     /*

--- a/business-archive/src/main/java/org/bonitasoft/engine/bpm/bar/BusinessArchiveFactory.java
+++ b/business-archive/src/main/java/org/bonitasoft/engine/bpm/bar/BusinessArchiveFactory.java
@@ -49,6 +49,7 @@ public class BusinessArchiveFactory {
         contributions.add(new DocumentsResourcesContribution());
         contributions.add(new ClasspathContribution());
         contributions.add(new FormMappingContribution());
+        contributions.add(new JarlessMarkerContribution());
     }
 
     private static final BusinessArchiveFactory INSTANCE = new BusinessArchiveFactory();

--- a/business-archive/src/main/java/org/bonitasoft/engine/bpm/bar/JarlessMarkerContribution.java
+++ b/business-archive/src/main/java/org/bonitasoft/engine/bpm/bar/JarlessMarkerContribution.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (C) 2025 Bonitasoft S.A.
+ * Bonitasoft, 32 rue Gustave Eiffel - 38000 Grenoble
+ * This library is free software; you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation
+ * version 2.1 of the License.
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth
+ * Floor, Boston, MA 02110-1301, USA.
+ **/
+package org.bonitasoft.engine.bpm.bar;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+/**
+ * Contributes the marker file for bars without dependency jars.
+ */
+public class JarlessMarkerContribution extends GenericFileContribution {
+
+    protected static final String JAR_LESS_MARKER_RESOURCE_PATH = ".jarless";
+
+    @Override
+    public String getFileName() {
+        return JAR_LESS_MARKER_RESOURCE_PATH;
+    }
+
+    @Override
+    public String getName() {
+        return getFileName();
+    }
+
+    @Override
+    public boolean readFromBarFolder(BusinessArchive businessArchive, File barFolder) {
+        // file is always empty
+        var file = barFolder.toPath().resolve(JAR_LESS_MARKER_RESOURCE_PATH);
+        if (Files.exists(file)) {
+            businessArchive.tagWithoutDependencyJars();
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public void saveToBarFolder(BusinessArchive businessArchive, File barFolder) throws IOException {
+        // file is always empty
+        if (!businessArchive.hasDependencyJars()) {
+            Files.write(barFolder.toPath().resolve(JAR_LESS_MARKER_RESOURCE_PATH), new byte[] {});
+        }
+    }
+
+    @Override
+    public boolean isMandatory() {
+        return false;
+    }
+
+}

--- a/business-archive/src/test/java/org/bonitasoft/engine/bpm/bar/BusinessArchiveBuilderTest.java
+++ b/business-archive/src/test/java/org/bonitasoft/engine/bpm/bar/BusinessArchiveBuilderTest.java
@@ -112,7 +112,8 @@ class BusinessArchiveBuilderTest {
 
         // then:
         assertThat(archive.hasDependencyJars()).isFalse();
-        assertThat(archive.getResource(".jarless")).isEmpty();
+        // marker does not count as a resource
+        assertThat(archive.getResource(".jarless")).isNull();
     }
 
     @Test

--- a/business-archive/src/test/java/org/bonitasoft/engine/bpm/bar/JarlessMarkerContributionTest.java
+++ b/business-archive/src/test/java/org/bonitasoft/engine/bpm/bar/JarlessMarkerContributionTest.java
@@ -82,5 +82,7 @@ class JarlessMarkerContributionTest {
         //then
         assertThat(present).isTrue();
         verify(businessArchive).tagWithoutDependencyJars();
+        // jarless tag does not count as a resource
+        assertThat(businessArchive.getResource(contribution.getName())).isNull();
     }
 }

--- a/business-archive/src/test/java/org/bonitasoft/engine/bpm/bar/JarlessMarkerContributionTest.java
+++ b/business-archive/src/test/java/org/bonitasoft/engine/bpm/bar/JarlessMarkerContributionTest.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (C) 2019 Bonitasoft S.A.
+ * Bonitasoft, 32 rue Gustave Eiffel - 38000 Grenoble
+ * This library is free software; you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation
+ * version 2.1 of the License.
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth
+ * Floor, Boston, MA 02110-1301, USA.
+ **/
+package org.bonitasoft.engine.bpm.bar;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.notNull;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class JarlessMarkerContributionTest {
+
+    @Mock
+    BusinessArchive businessArchive;
+
+    @Test
+    void should_not_be_mandatory_contribution() {
+        //given
+        JarlessMarkerContribution contribution = new JarlessMarkerContribution();
+
+        //when then
+        assertThat(contribution.isMandatory()).isFalse();
+
+    }
+
+    @Test
+    void should_have_a_name() {
+        //given
+        JarlessMarkerContribution contribution = new JarlessMarkerContribution();
+
+        //when then
+        assertThat(contribution.getName()).isEqualTo(".jarless");
+    }
+
+    @Test
+    void should_default_bar_not_be_jarless() throws Exception {
+        //given
+        JarlessMarkerContribution contribution = new JarlessMarkerContribution();
+        File barFolder = Paths.get(this.getClass().getResource("/barRoot").toURI()).toFile();
+
+        //when
+        boolean present = contribution.readFromBarFolder(businessArchive, barFolder);
+
+        //then
+        assertThat(present).isFalse();
+        verify(businessArchive, never()).addResource(eq(contribution.getName()), notNull());
+        verify(businessArchive, never()).tagWithoutDependencyJars();
+    }
+
+    @Test
+    void should_jarless_bar_have_marker(@TempDir Path tmpFolder) throws Exception {
+        //given
+        JarlessMarkerContribution contribution = new JarlessMarkerContribution();
+        File barFolder = tmpFolder.toFile();
+        new File(barFolder, contribution.getName()).createNewFile();
+
+        //when
+        boolean present = contribution.readFromBarFolder(businessArchive, barFolder);
+
+        //then
+        assertThat(present).isTrue();
+        verify(businessArchive).tagWithoutDependencyJars();
+    }
+}


### PR DESCRIPTION
Without a contributor, the .jarless marker is never persisted.

(to be releases in version 1.2.1)

Relates to [BPM-406](https://bonitasoft.atlassian.net/browse/BPM-406)

[BPM-406]: https://bonitasoft.atlassian.net/browse/BPM-406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ