### PR TITLE
fix(jarless_bar): ExternalResourceContribution reading too much files

### DIFF
--- a/business-archive/src/main/java/org/bonitasoft/engine/bpm/bar/ExternalResourceContribution.java
+++ b/business-archive/src/main/java/org/bonitasoft/engine/bpm/bar/ExternalResourceContribution.java
@@ -35,7 +35,7 @@ public class ExternalResourceContribution implements BusinessArchiveContribution
         final File externalResourceFolder = new File(barFolder, EXTERNAL_RESOURCE_FOLDER);
         if (externalResourceFolder.exists() && !externalResourceFolder.isFile()) {
             final BarResourceVisitor barResourceVisitor = new BarResourceVisitor(businessArchive, barFolder.toPath());
-            Files.walkFileTree(barFolder.toPath(), barResourceVisitor);
+            Files.walkFileTree(externalResourceFolder.toPath(), barResourceVisitor);
             return barResourceVisitor.getResourcesCount() > 0;
 
         }

--- a/business-archive/src/test/java/org/bonitasoft/engine/bpm/bar/BusinessArchiveFactoryTest.java
+++ b/business-archive/src/test/java/org/bonitasoft/engine/bpm/bar/BusinessArchiveFactoryTest.java
@@ -62,7 +62,8 @@ class BusinessArchiveFactoryTest {
     }
 
     @Test
-    void readBusinessArchiveFromFolderWithJarLessMarker(@TempDir Path tmpDir) throws Exception {
+    void should_readingBusinessArchiveFromFolderWithJarLessMarker_notAddResource(@TempDir Path tmpDir)
+            throws Exception {
         BusinessArchive businessArchive = createBusinessArchive();
         tmpDir.resolve(".jarless").toFile().createNewFile();
         BusinessArchiveFactory.writeBusinessArchiveToFolder(businessArchive, tmpDir.toFile());
@@ -70,7 +71,9 @@ class BusinessArchiveFactoryTest {
         var archive = BusinessArchiveFactory.readBusinessArchive(tmpDir.toFile());
 
         assertThat(archive).isNotNull();
+        // marker has correctly set hasDependencyJars property
         assertThat(archive.hasDependencyJars()).isFalse();
+        // .jarless marker is not added as a resource: it is not an external/classpath resource
         assertThat(archive.getResource(".jarless")).isNull();
         assertThat(archive.getProcessDefinition().getName()).isEqualTo("说话_éé");
     }

--- a/business-archive/src/test/java/org/bonitasoft/engine/bpm/bar/BusinessArchiveFactoryTest.java
+++ b/business-archive/src/test/java/org/bonitasoft/engine/bpm/bar/BusinessArchiveFactoryTest.java
@@ -62,6 +62,20 @@ class BusinessArchiveFactoryTest {
     }
 
     @Test
+    void readBusinessArchiveFromFolderWithJarLessMarker(@TempDir Path tmpDir) throws Exception {
+        BusinessArchive businessArchive = createBusinessArchive();
+        tmpDir.resolve(".jarless").toFile().createNewFile();
+        BusinessArchiveFactory.writeBusinessArchiveToFolder(businessArchive, tmpDir.toFile());
+
+        var archive = BusinessArchiveFactory.readBusinessArchive(tmpDir.toFile());
+
+        assertThat(archive).isNotNull();
+        assertThat(archive.hasDependencyJars()).isFalse();
+        assertThat(archive.getResource(".jarless")).isNull();
+        assertThat(archive.getProcessDefinition().getName()).isEqualTo("说话_éé");
+    }
+
+    @Test
     void readBusinessArchiveFromFolder(@TempDir Path tmpDir) throws Exception {
         BusinessArchive businessArchive = createBusinessArchive();
         BusinessArchiveFactory.writeBusinessArchiveToFolder(businessArchive, tmpDir.toFile());


### PR DESCRIPTION
ExternalResourceContribution should not read files out of the "resources" external resources folder.
This makes jarless bar validation fail.

Relates to [BPM-406](https://bonitasoft.atlassian.net/browse/BPM-406)

[BPM-406]: https://bonitasoft.atlassian.net/browse/BPM-406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ