### PR TITLE
chore(central-publishing): remove property waitUntil published

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -270,7 +270,6 @@
           <extensions>true</extensions>
           <configuration>
             <autoPublish>true</autoPublish>
-            <waitUntil>published</waitUntil>
             <excludeArtifacts>
               <artifact>bonita-artifacts-model-parent</artifact>
               <artifact>bonita-artifacts-model-coverage-report</artifact>


### PR DESCRIPTION
Remove `waitUntil=published` to prevent a long timeout (30 minutes) if the publication takes time.

Related to #164 