### PR TITLE
refactor: migrate from javax.xml.bind to jakarta.xml.bind

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,165 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is the **Bonita Artifacts Model** repository, which defines the runtime model for the Bonita BPM platform. It contains multiple Maven modules that define various domain models for applications, processes, business objects, connectors, forms, profiles, and organizations.
+
+The repository uses JAXB (XML binding) to generate Java classes from XML schemas and vice versa. Models defined as Java classes with JAXB annotations are used to serialize/deserialize XML configurations that define Bonita runtime artifacts.
+
+## Build Commands
+
+### Full Build
+```bash
+./mvnw clean verify
+```
+
+### Build Without Tests
+```bash
+./mvnw clean verify -DskipTests
+```
+
+### Compile Only
+```bash
+./mvnw clean compile
+```
+
+### Run Tests for a Specific Module
+```bash
+./mvnw test -f <module-name>/pom.xml
+```
+
+Example:
+```bash
+./mvnw test -f application-model/pom.xml
+```
+
+### Run a Single Test Class
+```bash
+./mvnw test -Dtest=ClassName -f <module-name>/pom.xml
+```
+
+### Format Code (Spotless)
+```bash
+./mvnw spotless:apply
+```
+
+### Check Code Format
+```bash
+./mvnw spotless:check
+```
+
+### Run Sonar Analysis
+```bash
+./mvnw sonar:sonar
+```
+
+## Module Architecture
+
+The project follows a multi-module Maven structure with the following key modules:
+
+### Core Model Modules
+- **common-artifacts-model**: Base classes and interfaces shared across all models (`BaseElement`, `NamedElement`, `DescriptionElement`, XML parser utilities)
+- **process-definition-model**: Complete BPMN process definition model (activities, gateways, events, data, contracts, connectors, contexts)
+- **business-object-model**: Business Data Model (BDM) definitions with query generators
+- **form-mapping-model**: Form mapping between processes/tasks and pages
+- **application-model**: Application descriptor model (menus, pages, links)
+- **organization-model**: Organization structure (users, groups, roles, memberships)
+- **profile-model**: User profile definitions
+- **connector-model**: Connector and user filter implementation descriptors
+- **bdm-access-control-model**: Business object access control rules
+- **business-archive**: Business Archive (BAR) format for packaging process definitions
+- **artifacts-model-dependencies**: BOM for dependency management
+- **coverage-report**: Aggregated Jacoco coverage report
+
+### Key Architecture Patterns
+
+1. **JAXB-Based XML Serialization**: Most modules use JAXB annotations (`@XmlRootElement`, `@XmlAttribute`, `@XmlElement`) to define the mapping between Java objects and XML. The `package-info.java` files define XML namespaces using `@XmlSchema`.
+
+2. **XSD Generation**: Several modules use the `jaxb2-maven-plugin` to automatically generate XSD schemas from annotated Java classes during the build (see `business-object-model`, `application-model`, `form-mapping-model`, etc.).
+
+3. **Builder Pattern**: Models use fluent builder APIs for constructing complex objects (e.g., `FormMappingModelBuilder`, `ApplicationNodeBuilder`).
+
+4. **Converter/Parser Pattern**: Dedicated converter and parser classes handle XML serialization/deserialization (e.g., `ApplicationNodeContainerConverter`, `OrganizationParser`, `BDMAccessControlParser`).
+
+5. **Contribution Pattern** (business-archive module): Uses a visitor-like pattern where `BusinessArchiveContribution` implementations handle specific artifact types in BAR files.
+
+## JAXB Migration Context
+
+The codebase is currently migrating from `javax.xml.bind` (JAXB 2.x) to `jakarta.xml.bind` (JAXB 3.x+). This is part of the Java EE to Jakarta EE transition. When working on this migration:
+
+- Replace `javax.xml.bind.*` imports with `jakarta.xml.bind.*`
+- Update `package-info.java` files that use `javax.xml.bind.annotation.*`
+- The current branch `refactor/xml-bind/move-from-javax-to-jakarta` is dedicated to this migration
+- After changing imports, run `./mvnw spotless:apply` to ensure proper formatting
+
+## Testing
+
+- Tests use **JUnit 5** (Jupiter) with AssertJ for assertions
+- Some modules use **Mockito** for mocking
+- Custom AssertJ assertions exist for domain objects (e.g., `BusinessObjectAssert`, `FieldAssert`)
+- Integration tests use Maven Failsafe plugin
+
+## Code Style and Formatting
+
+- The project uses **Spotless** with Eclipse formatter configuration
+- Formatter config: `formatter.xml`
+- Import order: `eclipse.importorder`
+- License header: `header.txt`
+- Always run `./mvnw spotless:apply` before committing
+- Spotless check runs automatically during `process-sources` phase
+
+## Commit Message Format
+
+Follow the conventional commit format:
+```
+type(category): description [flags]
+```
+
+Types: `breaking`, `build`, `ci`, `chore`, `docs`, `feat`, `fix`, `other`, `perf`, `refactor`, `revert`, `style`, `test`
+
+Example: `feat(business-object-model): add support for multiple queries`
+
+## Branching Strategy
+
+- Main development branch: **develop**
+- Uses **GitFlow** branching strategy
+- Feature branches: `feature/*`
+- Bugfix branches: `bugfix/*`
+- Hotfix branches: `hotfix/*`
+- Release branches: `release/*`
+
+## Java Version
+
+- Requires **Java 11** for compilation
+- Maven compiler is configured to target Java 11 (`maven.compiler.release=11`)
+- Uses Maven wrapper (`./mvnw`) - Maven 3.8.6+
+
+## Regenerating AssertJ Classes
+
+If you modify a model class and need to regenerate its AssertJ assertion class:
+
+1. Run `./mvnw clean compile` to ensure classes are compiled
+2. Delete the assertion class you want to regenerate
+3. Edit the module's `pom.xml` and add the AssertJ plugin configuration in the `<build>` section with the classes to regenerate
+4. Run `./mvnw assertj:generate-assertions -f <module>/pom.xml`
+5. Remove `@javax.annotation.Generated` annotations from generated classes
+6. Format with `./mvnw spotless:apply`
+7. Restore the original `pom.xml` (remove the plugin configuration)
+
+## Key Dependencies
+
+- **JAXB API/Runtime**: XML binding (transitioning from javax to jakarta)
+- **Jackson**: JSON processing (annotations, databind)
+- **Lombok**: Boilerplate reduction (getters, setters, builders)
+- **SLF4J 2.0**: Logging API
+- **JUnit 5**: Testing framework
+- **AssertJ**: Fluent assertions
+- **Mockito**: Mocking framework
+
+## Common Issues
+
+- If tests fail with XML parsing errors, ensure XSD schemas are generated: run `./mvnw clean compile` first
+- If spotless check fails, run `./mvnw spotless:apply` to auto-format
+- If you see JAXB class loading issues, check that both `jaxb-api` and `jaxb-runtime` dependencies are present with proper exclusions for `javax.activation`

--- a/application-model/pom.xml
+++ b/application-model/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.bonitasoft.engine</groupId>
     <artifactId>bonita-artifacts-model-parent</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>bonita-application-model</artifactId>
   <name>Bonita Application Model</name>
@@ -26,24 +26,12 @@
       <artifactId>bonita-common-artifacts-model</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.xml.bind</groupId>
-      <artifactId>jaxb-api</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>javax.activation</groupId>
-          <artifactId>javax.activation-api</artifactId>
-        </exclusion>
-      </exclusions>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jaxb</groupId>
       <artifactId>jaxb-runtime</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>javax.activation</groupId>
-          <artifactId>javax.activation-api</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.sun.activation</groupId>

--- a/application-model/src/main/java/org/bonitasoft/engine/business/application/exporter/ApplicationNodeContainerConverter.java
+++ b/application-model/src/main/java/org/bonitasoft/engine/business/application/exporter/ApplicationNodeContainerConverter.java
@@ -19,17 +19,18 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
 import javax.xml.XMLConstants;
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBElement;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Marshaller;
-import javax.xml.bind.Unmarshaller;
 import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
 
 import org.bonitasoft.engine.business.application.xml.ApplicationNodeContainer;
 import org.xml.sax.SAXException;
+
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBElement;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Marshaller;
+import jakarta.xml.bind.Unmarshaller;
 
 public class ApplicationNodeContainerConverter {
 

--- a/application-model/src/main/java/org/bonitasoft/engine/business/application/xml/AbstractApplicationNode.java
+++ b/application-model/src/main/java/org/bonitasoft/engine/business/application/xml/AbstractApplicationNode.java
@@ -15,10 +15,10 @@ package org.bonitasoft.engine.business.application.xml;
 
 import java.util.Objects;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
 
 /**
  * Abstract class for application nodes, which may have different concrete implementations.

--- a/application-model/src/main/java/org/bonitasoft/engine/business/application/xml/ApplicationLinkNode.java
+++ b/application-model/src/main/java/org/bonitasoft/engine/business/application/xml/ApplicationLinkNode.java
@@ -13,8 +13,8 @@
  **/
 package org.bonitasoft.engine.business.application.xml;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
 
 /**
  * Application node for Bonita Living Application as a link.

--- a/application-model/src/main/java/org/bonitasoft/engine/business/application/xml/ApplicationMenuNode.java
+++ b/application-model/src/main/java/org/bonitasoft/engine/business/application/xml/ApplicationMenuNode.java
@@ -18,11 +18,11 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlElementWrapper;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlElementWrapper;
 
 /**
  * @author Elias Ricken de Medeiros

--- a/application-model/src/main/java/org/bonitasoft/engine/business/application/xml/ApplicationNode.java
+++ b/application-model/src/main/java/org/bonitasoft/engine/business/application/xml/ApplicationNode.java
@@ -17,11 +17,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlElementWrapper;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlElementWrapper;
 
 /**
  * Application node for legacy Bonita Living Application.

--- a/application-model/src/main/java/org/bonitasoft/engine/business/application/xml/ApplicationNodeContainer.java
+++ b/application-model/src/main/java/org/bonitasoft/engine/business/application/xml/ApplicationNodeContainer.java
@@ -17,11 +17,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlElements;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlElements;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 /**
  * @author Elias Ricken de Medeiros

--- a/application-model/src/main/java/org/bonitasoft/engine/business/application/xml/ApplicationPageNode.java
+++ b/application-model/src/main/java/org/bonitasoft/engine/business/application/xml/ApplicationPageNode.java
@@ -15,9 +15,9 @@ package org.bonitasoft.engine.business.application.xml;
 
 import java.util.Objects;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
 
 /**
  * @author Elias Ricken de Medeiros

--- a/application-model/src/main/java/org/bonitasoft/engine/business/application/xml/package-info.java
+++ b/application-model/src/main/java/org/bonitasoft/engine/business/application/xml/package-info.java
@@ -19,6 +19,6 @@
         @XmlNs(prefix = "", namespaceURI = "http://documentation.bonitasoft.com/application-xml-schema/1.1") })
 package org.bonitasoft.engine.business.application.xml;
 
-import javax.xml.bind.annotation.XmlNs;
-import javax.xml.bind.annotation.XmlNsForm;
-import javax.xml.bind.annotation.XmlSchema;
+import jakarta.xml.bind.annotation.XmlNs;
+import jakarta.xml.bind.annotation.XmlNsForm;
+import jakarta.xml.bind.annotation.XmlSchema;

--- a/application-model/src/test/java/org/bonitasoft/engine/business/application/exporter/ApplicationNodeContainerConverterTest.java
+++ b/application-model/src/test/java/org/bonitasoft/engine/business/application/exporter/ApplicationNodeContainerConverterTest.java
@@ -20,10 +20,10 @@ import static org.bonitasoft.engine.business.application.xml.ApplicationNodeBuil
 import static org.bonitasoft.engine.business.application.xml.ApplicationNodeBuilder.newApplicationContainer;
 import static org.bonitasoft.engine.business.application.xml.ApplicationNodeBuilder.newApplicationLink;
 
-import javax.xml.bind.UnmarshalException;
-
 import org.bonitasoft.engine.business.application.xml.ApplicationNodeContainer;
 import org.junit.jupiter.api.Test;
+
+import jakarta.xml.bind.UnmarshalException;
 
 class ApplicationNodeContainerConverterTest {
 

--- a/artifacts-model-dependencies/pom.xml
+++ b/artifacts-model-dependencies/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.bonitasoft.engine</groupId>
     <artifactId>bonita-artifacts-model-parent</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>bonita-artifacts-model-dependencies</artifactId>
   <packaging>pom</packaging>
@@ -65,17 +65,17 @@
       <dependency>
         <groupId>com.sun.activation</groupId>
         <artifactId>jakarta.activation</artifactId>
-        <version>1.2.2</version>
+        <version>2.0.1</version>
       </dependency>
       <dependency>
-        <groupId>javax.xml.bind</groupId>
-        <artifactId>jaxb-api</artifactId>
-        <version>2.3.1</version>
+        <groupId>jakarta.xml.bind</groupId>
+        <artifactId>jakarta.xml.bind-api</artifactId>
+        <version>3.0.1</version>
       </dependency>
       <dependency>
         <groupId>org.glassfish.jaxb</groupId>
         <artifactId>jaxb-runtime</artifactId>
-        <version>2.3.1</version>
+        <version>3.0.2</version>
       </dependency>
       <dependency>
         <groupId>org.glassfish.hk2</groupId>

--- a/bdm-access-control-model/pom.xml
+++ b/bdm-access-control-model/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.bonitasoft.engine</groupId>
     <artifactId>bonita-artifacts-model-parent</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>bonita-bdm-access-control-model</artifactId>
   <name>BDM Access Control Model</name>
@@ -30,24 +30,12 @@
       <artifactId>bonita-business-object-model</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.xml.bind</groupId>
-      <artifactId>jaxb-api</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>javax.activation</groupId>
-          <artifactId>javax.activation-api</artifactId>
-        </exclusion>
-      </exclusions>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jaxb</groupId>
       <artifactId>jaxb-runtime</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>javax.activation</groupId>
-          <artifactId>javax.activation-api</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.sun.activation</groupId>

--- a/bdm-access-control-model/src/main/java/com/bonitasoft/engine/bdm/accesscontrol/BDMAccessControlParser.java
+++ b/bdm-access-control-model/src/main/java/com/bonitasoft/engine/bdm/accesscontrol/BDMAccessControlParser.java
@@ -16,13 +16,13 @@ package com.bonitasoft.engine.bdm.accesscontrol;
 import java.net.URL;
 import java.util.Optional;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-
 import org.bonitasoft.engine.xml.parser.AbstractParser;
 import org.glassfish.hk2.osgiresourcelocator.ResourceFinder;
 
 import com.bonitasoft.engine.bdm.accesscontrol.model.BusinessObjectAccessControlModel;
+
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
 
 /**
  * @author Adrien Lachambre

--- a/bdm-access-control-model/src/main/java/com/bonitasoft/engine/bdm/accesscontrol/model/AccessRule.java
+++ b/bdm-access-control-model/src/main/java/com/bonitasoft/engine/bdm/accesscontrol/model/AccessRule.java
@@ -17,14 +17,14 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlElementWrapper;
-import javax.xml.bind.annotation.XmlType;
-
 import org.bonitasoft.engine.bdm.model.NamedElement;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlElementWrapper;
+import jakarta.xml.bind.annotation.XmlType;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(propOrder = { "name", "usingDynamicProfiles", "description", "condition", "staticProfiles", "dynamicProfiles",

--- a/bdm-access-control-model/src/main/java/com/bonitasoft/engine/bdm/accesscontrol/model/Attribute.java
+++ b/bdm-access-control-model/src/main/java/com/bonitasoft/engine/bdm/accesscontrol/model/Attribute.java
@@ -13,12 +13,12 @@
  **/
 package com.bonitasoft.engine.bdm.accesscontrol.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-
 import org.bonitasoft.engine.bdm.model.NamedElement;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 public class Attribute implements NamedElement {

--- a/bdm-access-control-model/src/main/java/com/bonitasoft/engine/bdm/accesscontrol/model/AttributesWrapper.java
+++ b/bdm-access-control-model/src/main/java/com/bonitasoft/engine/bdm/accesscontrol/model/AttributesWrapper.java
@@ -16,10 +16,10 @@ package com.bonitasoft.engine.bdm.accesscontrol.model;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 public class AttributesWrapper {

--- a/bdm-access-control-model/src/main/java/com/bonitasoft/engine/bdm/accesscontrol/model/BusinessObjectAccessControlModel.java
+++ b/bdm-access-control-model/src/main/java/com/bonitasoft/engine/bdm/accesscontrol/model/BusinessObjectAccessControlModel.java
@@ -17,12 +17,12 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlType;
 
 /**
  * @author Adrien Lachambre, Emmanuel Duchastenier

--- a/bdm-access-control-model/src/main/java/com/bonitasoft/engine/bdm/accesscontrol/model/BusinessObjectRule.java
+++ b/bdm-access-control-model/src/main/java/com/bonitasoft/engine/bdm/accesscontrol/model/BusinessObjectRule.java
@@ -17,12 +17,12 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlID;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlID;
+import jakarta.xml.bind.annotation.XmlType;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(propOrder = { "businessObjectQualifiedName", "rules" })

--- a/bdm-access-control-model/src/main/java/com/bonitasoft/engine/bdm/accesscontrol/model/package-info.java
+++ b/bdm-access-control-model/src/main/java/com/bonitasoft/engine/bdm/accesscontrol/model/package-info.java
@@ -14,6 +14,6 @@
         @XmlNs(prefix = "", namespaceURI = "http://documentation.bonitasoft.com/bdm-access-control-xml-schema/1.0") })
 package com.bonitasoft.engine.bdm.accesscontrol.model;
 
-import javax.xml.bind.annotation.XmlNs;
-import javax.xml.bind.annotation.XmlNsForm;
-import javax.xml.bind.annotation.XmlSchema;
+import jakarta.xml.bind.annotation.XmlNs;
+import jakarta.xml.bind.annotation.XmlNsForm;
+import jakarta.xml.bind.annotation.XmlSchema;

--- a/bdm-access-control-model/src/test/java/com/bonitasoft/engine/bdm/accesscontrol/BDMAccessControlParserTest.java
+++ b/bdm-access-control-model/src/test/java/com/bonitasoft/engine/bdm/accesscontrol/BDMAccessControlParserTest.java
@@ -23,8 +23,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-import javax.xml.bind.UnmarshalException;
-
 import org.junit.jupiter.api.Test;
 
 import com.bonitasoft.engine.bdm.accesscontrol.builder.AccessRuleBuilder;
@@ -35,6 +33,8 @@ import com.bonitasoft.engine.bdm.accesscontrol.model.Attribute;
 import com.bonitasoft.engine.bdm.accesscontrol.model.AttributesWrapper;
 import com.bonitasoft.engine.bdm.accesscontrol.model.BusinessObjectAccessControlModel;
 import com.bonitasoft.engine.bdm.accesscontrol.model.BusinessObjectRule;
+
+import jakarta.xml.bind.UnmarshalException;
 
 class BDMAccessControlParserTest {
 

--- a/business-archive/pom.xml
+++ b/business-archive/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.bonitasoft.engine</groupId>
     <artifactId>bonita-artifacts-model-parent</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>bonita-business-archive</artifactId>
   <name>Bonita Business Archive</name>
@@ -30,24 +30,12 @@
       <artifactId>bonita-form-mapping-model</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.xml.bind</groupId>
-      <artifactId>jaxb-api</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>javax.activation</groupId>
-          <artifactId>javax.activation-api</artifactId>
-        </exclusion>
-      </exclusions>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jaxb</groupId>
       <artifactId>jaxb-runtime</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>javax.activation</groupId>
-          <artifactId>javax.activation-api</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.sun.activation</groupId>

--- a/business-archive/src/main/java/org/bonitasoft/engine/bpm/bar/ActorMappingMarshaller.java
+++ b/business-archive/src/main/java/org/bonitasoft/engine/bpm/bar/ActorMappingMarshaller.java
@@ -17,14 +17,15 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBElement;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Marshaller;
-import javax.xml.bind.Unmarshaller;
 import javax.xml.transform.stream.StreamSource;
 
 import org.bonitasoft.engine.bpm.bar.actorMapping.ActorMapping;
+
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBElement;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Marshaller;
+import jakarta.xml.bind.Unmarshaller;
 
 /**
  * @author mazourd

--- a/business-archive/src/main/java/org/bonitasoft/engine/bpm/bar/FormMappingContribution.java
+++ b/business-archive/src/main/java/org/bonitasoft/engine/bpm/bar/FormMappingContribution.java
@@ -17,11 +17,11 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 
-import javax.xml.bind.JAXBException;
-
 import org.bonitasoft.engine.bpm.bar.form.model.FormMappingModel;
 import org.bonitasoft.engine.bpm.form.FormMappingModelMarshaller;
 import org.xml.sax.SAXException;
+
+import jakarta.xml.bind.JAXBException;
 
 /**
  * @author Emmanuel Duchastenier

--- a/business-archive/src/main/java/org/bonitasoft/engine/bpm/bar/ProcessDefinitionBARContribution.java
+++ b/business-archive/src/main/java/org/bonitasoft/engine/bpm/bar/ProcessDefinitionBARContribution.java
@@ -26,11 +26,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import javax.xml.XMLConstants;
-import javax.xml.bind.DataBindingException;
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Marshaller;
-import javax.xml.bind.Unmarshaller;
 import javax.xml.validation.SchemaFactory;
 
 import org.bonitasoft.engine.bpm.flownode.ActivityDefinition;
@@ -55,6 +50,12 @@ import org.bonitasoft.engine.bpm.process.impl.internal.DesignProcessDefinitionIm
 import org.bonitasoft.engine.bpm.process.impl.internal.SubProcessDefinitionImpl;
 import org.glassfish.hk2.osgiresourcelocator.ResourceFinder;
 import org.xml.sax.SAXException;
+
+import jakarta.xml.bind.DataBindingException;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Marshaller;
+import jakarta.xml.bind.Unmarshaller;
 
 /**
  * @author Baptiste Mesta

--- a/business-archive/src/main/java/org/bonitasoft/engine/bpm/bar/actorMapping/Actor.java
+++ b/business-archive/src/main/java/org/bonitasoft/engine/bpm/bar/actorMapping/Actor.java
@@ -19,12 +19,11 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlElementWrapper;
-
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlElementWrapper;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;

--- a/business-archive/src/main/java/org/bonitasoft/engine/bpm/bar/actorMapping/ActorMapping.java
+++ b/business-archive/src/main/java/org/bonitasoft/engine/bpm/bar/actorMapping/ActorMapping.java
@@ -17,11 +17,10 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/business-archive/src/main/java/org/bonitasoft/engine/bpm/bar/actorMapping/package-info.java
+++ b/business-archive/src/main/java/org/bonitasoft/engine/bpm/bar/actorMapping/package-info.java
@@ -17,8 +17,8 @@
  * </p>
  */
 @XmlSchema(namespace = "http://www.bonitasoft.org/ns/actormapping/6.0", elementFormDefault = XmlNsForm.UNSET, xmlns = {
-        @javax.xml.bind.annotation.XmlNs(namespaceURI = "http://www.bonitasoft.org/ns/actormapping/6.0", prefix = "actorMappings") })
+        @jakarta.xml.bind.annotation.XmlNs(namespaceURI = "http://www.bonitasoft.org/ns/actormapping/6.0", prefix = "actorMappings") })
 package org.bonitasoft.engine.bpm.bar.actorMapping;
 
-import javax.xml.bind.annotation.XmlNsForm;
-import javax.xml.bind.annotation.XmlSchema;
+import jakarta.xml.bind.annotation.XmlNsForm;
+import jakarta.xml.bind.annotation.XmlSchema;

--- a/business-object-model/pom.xml
+++ b/business-object-model/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.bonitasoft.engine</groupId>
     <artifactId>bonita-artifacts-model-parent</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>bonita-business-object-model</artifactId>
   <name>Bonita Business Object Model</name>
@@ -22,24 +22,12 @@
   </dependencyManagement>
   <dependencies>
     <dependency>
-      <groupId>javax.xml.bind</groupId>
-      <artifactId>jaxb-api</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>javax.activation</groupId>
-          <artifactId>javax.activation-api</artifactId>
-        </exclusion>
-      </exclusions>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jaxb</groupId>
       <artifactId>jaxb-runtime</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>javax.activation</groupId>
-          <artifactId>javax.activation-api</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.sun.activation</groupId>

--- a/business-object-model/src/main/java/org/bonitasoft/engine/bdm/BusinessObjectModelConverter.java
+++ b/business-object-model/src/main/java/org/bonitasoft/engine/bdm/BusinessObjectModelConverter.java
@@ -26,11 +26,6 @@ import java.util.zip.ZipInputStream;
 import java.util.zip.ZipOutputStream;
 
 import javax.xml.XMLConstants;
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBElement;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Marshaller;
-import javax.xml.bind.Unmarshaller;
 import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
@@ -38,6 +33,12 @@ import javax.xml.validation.SchemaFactory;
 import org.bonitasoft.engine.bdm.model.BusinessObjectModel;
 import org.glassfish.hk2.osgiresourcelocator.ResourceFinder;
 import org.xml.sax.SAXException;
+
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBElement;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Marshaller;
+import jakarta.xml.bind.Unmarshaller;
 
 /**
  * @author Matthieu Chaffotte

--- a/business-object-model/src/main/java/org/bonitasoft/engine/bdm/model/BusinessObject.java
+++ b/business-object-model/src/main/java/org/bonitasoft/engine/bdm/model/BusinessObject.java
@@ -20,20 +20,20 @@ import java.util.List;
 import java.util.Objects;
 import java.util.StringJoiner;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlElementWrapper;
-import javax.xml.bind.annotation.XmlElements;
-import javax.xml.bind.annotation.XmlID;
-import javax.xml.bind.annotation.XmlType;
-
 import org.bonitasoft.engine.bdm.BDMSimpleNameProvider;
 import org.bonitasoft.engine.bdm.model.field.Field;
 import org.bonitasoft.engine.bdm.model.field.RelationField;
 import org.bonitasoft.engine.bdm.model.field.RelationField.Type;
 import org.bonitasoft.engine.bdm.model.field.SimpleField;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlElementWrapper;
+import jakarta.xml.bind.annotation.XmlElements;
+import jakarta.xml.bind.annotation.XmlID;
+import jakarta.xml.bind.annotation.XmlType;
 
 /**
  * @author Matthieu Chaffotte

--- a/business-object-model/src/main/java/org/bonitasoft/engine/bdm/model/BusinessObjectModel.java
+++ b/business-object-model/src/main/java/org/bonitasoft/engine/bdm/model/BusinessObjectModel.java
@@ -20,12 +20,12 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.StringJoiner;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlElementWrapper;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlElementWrapper;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 /**
  * @author Matthieu Chaffotte

--- a/business-object-model/src/main/java/org/bonitasoft/engine/bdm/model/Index.java
+++ b/business-object-model/src/main/java/org/bonitasoft/engine/bdm/model/Index.java
@@ -17,11 +17,11 @@ import java.util.List;
 import java.util.Objects;
 import java.util.StringJoiner;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlElementWrapper;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlElementWrapper;
 
 /**
  * @author Matthieu Chaffotte

--- a/business-object-model/src/main/java/org/bonitasoft/engine/bdm/model/Query.java
+++ b/business-object-model/src/main/java/org/bonitasoft/engine/bdm/model/Query.java
@@ -18,11 +18,11 @@ import java.util.List;
 import java.util.Objects;
 import java.util.StringJoiner;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlElementWrapper;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlElementWrapper;
 
 /**
  * @author Matthieu Chaffotte

--- a/business-object-model/src/main/java/org/bonitasoft/engine/bdm/model/QueryParameter.java
+++ b/business-object-model/src/main/java/org/bonitasoft/engine/bdm/model/QueryParameter.java
@@ -15,10 +15,10 @@ package org.bonitasoft.engine.bdm.model;
 
 import java.util.Objects;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
 
 /**
  * @author Matthieu Chaffotte

--- a/business-object-model/src/main/java/org/bonitasoft/engine/bdm/model/UniqueConstraint.java
+++ b/business-object-model/src/main/java/org/bonitasoft/engine/bdm/model/UniqueConstraint.java
@@ -17,11 +17,11 @@ import java.util.List;
 import java.util.Objects;
 import java.util.StringJoiner;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlElementWrapper;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlElementWrapper;
 
 /**
  * @author Matthieu Chaffotte

--- a/business-object-model/src/main/java/org/bonitasoft/engine/bdm/model/field/Field.java
+++ b/business-object-model/src/main/java/org/bonitasoft/engine/bdm/model/field/Field.java
@@ -15,11 +15,11 @@ package org.bonitasoft.engine.bdm.model.field;
 
 import java.util.Objects;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlType;
 
 /**
  * @author Colin PUY

--- a/business-object-model/src/main/java/org/bonitasoft/engine/bdm/model/field/RelationField.java
+++ b/business-object-model/src/main/java/org/bonitasoft/engine/bdm/model/field/RelationField.java
@@ -16,11 +16,11 @@ package org.bonitasoft.engine.bdm.model.field;
 import java.util.Objects;
 import java.util.StringJoiner;
 
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlIDREF;
-import javax.xml.bind.annotation.XmlType;
-
 import org.bonitasoft.engine.bdm.model.BusinessObject;
+
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlIDREF;
+import jakarta.xml.bind.annotation.XmlType;
 
 /**
  * @author Colin PUY

--- a/business-object-model/src/main/java/org/bonitasoft/engine/bdm/model/field/SimpleField.java
+++ b/business-object-model/src/main/java/org/bonitasoft/engine/bdm/model/field/SimpleField.java
@@ -16,8 +16,8 @@ package org.bonitasoft.engine.bdm.model.field;
 import java.util.Objects;
 import java.util.StringJoiner;
 
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlType;
 
 /**
  * @author Matthieu Chaffotte

--- a/business-object-model/src/main/java/org/bonitasoft/engine/bdm/model/field/package-info.java
+++ b/business-object-model/src/main/java/org/bonitasoft/engine/bdm/model/field/package-info.java
@@ -15,6 +15,6 @@
         @XmlNs(prefix = "", namespaceURI = "http://documentation.bonitasoft.com/bdm-xml-schema/1.0") })
 package org.bonitasoft.engine.bdm.model.field;
 
-import javax.xml.bind.annotation.XmlNs;
-import javax.xml.bind.annotation.XmlNsForm;
-import javax.xml.bind.annotation.XmlSchema;
+import jakarta.xml.bind.annotation.XmlNs;
+import jakarta.xml.bind.annotation.XmlNsForm;
+import jakarta.xml.bind.annotation.XmlSchema;

--- a/business-object-model/src/main/java/org/bonitasoft/engine/bdm/model/package-info.java
+++ b/business-object-model/src/main/java/org/bonitasoft/engine/bdm/model/package-info.java
@@ -15,6 +15,6 @@
         @XmlNs(prefix = "", namespaceURI = "http://documentation.bonitasoft.com/bdm-xml-schema/1.0") })
 package org.bonitasoft.engine.bdm.model;
 
-import javax.xml.bind.annotation.XmlNs;
-import javax.xml.bind.annotation.XmlNsForm;
-import javax.xml.bind.annotation.XmlSchema;
+import jakarta.xml.bind.annotation.XmlNs;
+import jakarta.xml.bind.annotation.XmlNsForm;
+import jakarta.xml.bind.annotation.XmlSchema;

--- a/business-object-model/src/test/java/org/bonitasoft/engine/bdm/BusinessObjectModelConverterTest.java
+++ b/business-object-model/src/test/java/org/bonitasoft/engine/bdm/BusinessObjectModelConverterTest.java
@@ -21,11 +21,11 @@ import java.io.IOException;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
-import javax.xml.bind.JAXBException;
-
 import org.bonitasoft.engine.bdm.builder.BusinessObjectModelBuilder;
 import org.bonitasoft.engine.bdm.model.BusinessObjectModel;
 import org.junit.jupiter.api.Test;
+
+import jakarta.xml.bind.JAXBException;
 
 class BusinessObjectModelConverterTest {
 

--- a/business-object-model/src/test/java/org/bonitasoft/engine/bdm/model/assertion/BusinessObjectAssert.java
+++ b/business-object-model/src/test/java/org/bonitasoft/engine/bdm/model/assertion/BusinessObjectAssert.java
@@ -17,8 +17,6 @@ import static org.bonitasoft.engine.bdm.builder.BusinessObjectModelBuilder.aBOM;
 
 import java.io.IOException;
 
-import javax.xml.bind.JAXBException;
-
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.Assertions;
 import org.bonitasoft.engine.bdm.builder.BusinessObjectModelBuilder;
@@ -27,6 +25,8 @@ import org.bonitasoft.engine.bdm.model.BusinessObjectModel;
 import org.bonitasoft.engine.bdm.model.field.Field;
 import org.bonitasoft.engine.bdm.model.field.RelationField;
 import org.xml.sax.SAXException;
+
+import jakarta.xml.bind.JAXBException;
 
 /**
  * @author Colin PUY

--- a/business-object-model/src/test/java/org/bonitasoft/engine/bdm/model/assertion/FieldAssert.java
+++ b/business-object-model/src/test/java/org/bonitasoft/engine/bdm/model/assertion/FieldAssert.java
@@ -18,8 +18,6 @@ import static org.bonitasoft.engine.bdm.builder.BusinessObjectModelBuilder.aBOM;
 
 import java.io.IOException;
 
-import javax.xml.bind.JAXBException;
-
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.Assertions;
 import org.bonitasoft.engine.bdm.builder.BusinessObjectModelBuilder;
@@ -27,6 +25,8 @@ import org.bonitasoft.engine.bdm.model.BusinessObjectModel;
 import org.bonitasoft.engine.bdm.model.field.Field;
 import org.bonitasoft.engine.bdm.model.field.RelationField;
 import org.xml.sax.SAXException;
+
+import jakarta.xml.bind.JAXBException;
 
 public class FieldAssert extends AbstractAssert<FieldAssert, Field> {
 

--- a/business-object-model/src/test/java/org/bonitasoft/engine/bdm/model/assertion/Marshaller.java
+++ b/business-object-model/src/test/java/org/bonitasoft/engine/bdm/model/assertion/Marshaller.java
@@ -15,11 +15,11 @@ package org.bonitasoft.engine.bdm.model.assertion;
 
 import java.io.IOException;
 
-import javax.xml.bind.JAXBException;
-
 import org.bonitasoft.engine.bdm.BusinessObjectModelConverter;
 import org.bonitasoft.engine.bdm.model.BusinessObjectModel;
 import org.xml.sax.SAXException;
+
+import jakarta.xml.bind.JAXBException;
 
 public class Marshaller {
 

--- a/common-artifacts-model/pom.xml
+++ b/common-artifacts-model/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.bonitasoft.engine</groupId>
     <artifactId>bonita-artifacts-model-parent</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>bonita-common-artifacts-model</artifactId>
   <name>Bonita Common Artifacts Model</name>
@@ -22,24 +22,12 @@
   </dependencyManagement>
   <dependencies>
     <dependency>
-      <groupId>javax.xml.bind</groupId>
-      <artifactId>jaxb-api</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>javax.activation</groupId>
-          <artifactId>javax.activation-api</artifactId>
-        </exclusion>
-      </exclusions>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jaxb</groupId>
       <artifactId>jaxb-runtime</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>javax.activation</groupId>
-          <artifactId>javax.activation-api</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.sun.activation</groupId>

--- a/common-artifacts-model/src/main/java/org/bonitasoft/engine/bpm/internal/BaseDefinitionElementImpl.java
+++ b/common-artifacts-model/src/main/java/org/bonitasoft/engine/bpm/internal/BaseDefinitionElementImpl.java
@@ -15,15 +15,14 @@ package org.bonitasoft.engine.bpm.internal;
 
 import java.util.UUID;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlID;
-import javax.xml.bind.annotation.XmlTransient;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
-
 import org.bonitasoft.engine.bpm.BaseElement;
 
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlID;
+import jakarta.xml.bind.annotation.XmlTransient;
+import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/common-artifacts-model/src/main/java/org/bonitasoft/engine/bpm/internal/LongToStringAdapter.java
+++ b/common-artifacts-model/src/main/java/org/bonitasoft/engine/bpm/internal/LongToStringAdapter.java
@@ -13,7 +13,7 @@
  **/
 package org.bonitasoft.engine.bpm.internal;
 
-import javax.xml.bind.annotation.adapters.XmlAdapter;
+import jakarta.xml.bind.annotation.adapters.XmlAdapter;
 
 /**
  * @author mazourd

--- a/common-artifacts-model/src/main/java/org/bonitasoft/engine/bpm/internal/NamedDefinitionElementImpl.java
+++ b/common-artifacts-model/src/main/java/org/bonitasoft/engine/bpm/internal/NamedDefinitionElementImpl.java
@@ -13,13 +13,12 @@
  **/
 package org.bonitasoft.engine.bpm.internal;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlTransient;
-
 import org.bonitasoft.engine.bpm.NamedElement;
 
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlTransient;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;

--- a/common-artifacts-model/src/main/java/org/bonitasoft/engine/xml/parser/AbstractParser.java
+++ b/common-artifacts-model/src/main/java/org/bonitasoft/engine/xml/parser/AbstractParser.java
@@ -18,13 +18,14 @@ import java.io.StringWriter;
 import java.net.URL;
 
 import javax.xml.XMLConstants;
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Marshaller;
-import javax.xml.bind.Unmarshaller;
 import javax.xml.validation.SchemaFactory;
 
 import org.xml.sax.SAXException;
+
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Marshaller;
+import jakarta.xml.bind.Unmarshaller;
 
 /**
  * @author Adrien Lachambre

--- a/connector-model/pom.xml
+++ b/connector-model/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.bonitasoft.engine</groupId>
     <artifactId>bonita-artifacts-model-parent</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>bonita-connector-model</artifactId>
   <name>Bonita Connector Model</name>
@@ -26,24 +26,12 @@
       <artifactId>bonita-common-artifacts-model</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.xml.bind</groupId>
-      <artifactId>jaxb-api</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>javax.activation</groupId>
-          <artifactId>javax.activation-api</artifactId>
-        </exclusion>
-      </exclusions>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jaxb</groupId>
       <artifactId>jaxb-runtime</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>javax.activation</groupId>
-          <artifactId>javax.activation-api</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.sun.activation</groupId>

--- a/connector-model/src/main/java/org/bonitasoft/engine/core/connector/parser/AbstractConnectorImplementationParser.java
+++ b/connector-model/src/main/java/org/bonitasoft/engine/core/connector/parser/AbstractConnectorImplementationParser.java
@@ -16,10 +16,10 @@ package org.bonitasoft.engine.core.connector.parser;
 import java.net.URL;
 import java.util.Optional;
 
-import javax.xml.bind.JAXBException;
-
 import org.bonitasoft.engine.xml.parser.AbstractParser;
 import org.glassfish.hk2.osgiresourcelocator.ResourceFinder;
+
+import jakarta.xml.bind.JAXBException;
 
 /**
  * Abstract class to define common configuration between connector implementation parsers.

--- a/connector-model/src/main/java/org/bonitasoft/engine/core/connector/parser/ConnectorImplementationParser.java
+++ b/connector-model/src/main/java/org/bonitasoft/engine/core/connector/parser/ConnectorImplementationParser.java
@@ -13,8 +13,8 @@
  **/
 package org.bonitasoft.engine.core.connector.parser;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
 
 public class ConnectorImplementationParser
         extends AbstractConnectorImplementationParser<SConnectorImplementationDescriptor> {

--- a/connector-model/src/main/java/org/bonitasoft/engine/core/connector/parser/SConnectorImplementationDescriptor.java
+++ b/connector-model/src/main/java/org/bonitasoft/engine/core/connector/parser/SConnectorImplementationDescriptor.java
@@ -18,12 +18,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.StringJoiner;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlElementWrapper;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlElementWrapper;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlType;
 
 /**
  * @author Feng Hui

--- a/connector-model/src/main/java/org/bonitasoft/engine/core/connector/parser/package-info.java
+++ b/connector-model/src/main/java/org/bonitasoft/engine/core/connector/parser/package-info.java
@@ -15,5 +15,5 @@
         @XmlNs(prefix = "implementation", namespaceURI = "http://www.bonitasoft.org/ns/connector/implementation/6.0") })
 package org.bonitasoft.engine.core.connector.parser;
 
-import javax.xml.bind.annotation.XmlNs;
-import javax.xml.bind.annotation.XmlSchema;
+import jakarta.xml.bind.annotation.XmlNs;
+import jakarta.xml.bind.annotation.XmlSchema;

--- a/connector-model/src/main/java/org/bonitasoft/engine/core/filter/model/JarDependencies.java
+++ b/connector-model/src/main/java/org/bonitasoft/engine/core/filter/model/JarDependencies.java
@@ -17,9 +17,9 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
 
 /**
  * @author Yanyan Liu

--- a/connector-model/src/main/java/org/bonitasoft/engine/core/filter/model/UserFilterImplementationDescriptor.java
+++ b/connector-model/src/main/java/org/bonitasoft/engine/core/filter/model/UserFilterImplementationDescriptor.java
@@ -16,11 +16,11 @@ package org.bonitasoft.engine.core.filter.model;
 import java.io.Serializable;
 import java.util.StringJoiner;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlType;
 
 /**
  * @author Baptiste Mesta

--- a/connector-model/src/main/java/org/bonitasoft/engine/core/filter/model/UserFilterImplementationParser.java
+++ b/connector-model/src/main/java/org/bonitasoft/engine/core/filter/model/UserFilterImplementationParser.java
@@ -13,10 +13,10 @@
  **/
 package org.bonitasoft.engine.core.filter.model;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-
 import org.bonitasoft.engine.core.connector.parser.AbstractConnectorImplementationParser;
+
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
 
 public class UserFilterImplementationParser
         extends AbstractConnectorImplementationParser<UserFilterImplementationDescriptor> {

--- a/connector-model/src/main/java/org/bonitasoft/engine/core/filter/model/package-info.java
+++ b/connector-model/src/main/java/org/bonitasoft/engine/core/filter/model/package-info.java
@@ -15,5 +15,5 @@
         @XmlNs(prefix = "implementation", namespaceURI = "http://www.bonitasoft.org/ns/connector/implementation/6.0") })
 package org.bonitasoft.engine.core.filter.model;
 
-import javax.xml.bind.annotation.XmlNs;
-import javax.xml.bind.annotation.XmlSchema;
+import jakarta.xml.bind.annotation.XmlNs;
+import jakarta.xml.bind.annotation.XmlSchema;

--- a/coverage-report/pom.xml
+++ b/coverage-report/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.bonitasoft.engine</groupId>
     <artifactId>bonita-artifacts-model-parent</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>bonita-artifacts-model-coverage-report</artifactId>
   <packaging>pom</packaging>

--- a/doc/adr/javax-to-jakarta-migration-plan.md
+++ b/doc/adr/javax-to-jakarta-migration-plan.md
@@ -1,0 +1,311 @@
+# Architecture Decision Record: javax to jakarta XML Binding Migration
+
+## Status
+Proposed
+
+## Context
+
+The Java EE platform has been transferred to the Eclipse Foundation and rebranded as Jakarta EE. As part of this transition, all `javax.*` namespaces have been migrated to `jakarta.*` namespaces starting with Jakarta EE 9.
+
+This project currently uses:
+- `javax.xml.bind:jaxb-api:2.3.1` (Java EE 8)
+- `org.glassfish.jaxb:jaxb-runtime:2.3.1` (Java EE 8)
+
+We need to migrate to:
+- `jakarta.xml.bind:jakarta.xml.bind-api:3.0.0+` (Jakarta EE 9+)
+- `org.glassfish.jaxb:jaxb-runtime:3.0.0+` (Jakarta EE 9+)
+
+### Impact Analysis
+
+**Affected Modules:** 11 of 12 modules
+**Affected Java Files:** 148 files (141 source + 7 test)
+**Affected POMs:** 11 module POMs + 1 BOM
+
+**Critical Files:**
+- `common-artifacts-model`: Base classes used by all other modules
+- `artifacts-model-dependencies`: BOM that centralizes dependency versions
+
+## Decision
+
+We will migrate all `javax.xml.bind.*` imports to `jakarta.xml.bind.*` across the entire codebase in a single, atomic change.
+
+### Migration Strategy
+
+#### Phase 1: Dependency Updates (Maven POMs)
+1. Update BOM (`artifacts-model-dependencies/pom.xml`) first
+2. All other modules inherit from BOM
+3. No version changes needed in individual module POMs
+
+#### Phase 2: Java Code Updates
+1. Update `common-artifacts-model` first (base classes)
+2. Update remaining modules in dependency order
+3. Use automated find-replace for consistency
+
+#### Phase 3: Testing & Validation
+1. Run full build to verify compilation
+2. Execute test suite to verify functionality
+3. Verify XSD generation still works correctly
+
+## Implementation Plan
+
+### 1. Maven Dependency Updates
+
+**File:** `artifacts-model-dependencies/pom.xml`
+
+Replace:
+```xml
+<dependency>
+  <groupId>javax.xml.bind</groupId>
+  <artifactId>jaxb-api</artifactId>
+  <version>2.3.1</version>
+</dependency>
+<dependency>
+  <groupId>org.glassfish.jaxb</groupId>
+  <artifactId>jaxb-runtime</artifactId>
+  <version>2.3.1</version>
+</dependency>
+```
+
+With:
+```xml
+<dependency>
+  <groupId>jakarta.xml.bind</groupId>
+  <artifactId>jakarta.xml.bind-api</artifactId>
+  <version>3.0.1</version>
+</dependency>
+<dependency>
+  <groupId>org.glassfish.jaxb</groupId>
+  <artifactId>jaxb-runtime</artifactId>
+  <version>3.0.2</version>
+</dependency>
+```
+
+**Note:** Keep `com.sun.activation:jakarta.activation:1.2.2` as-is (already Jakarta).
+
+**Update all module POMs** (11 files):
+- Replace `javax.xml.bind:jaxb-api` → `jakarta.xml.bind:jakarta.xml.bind-api`
+- Keep exclusions for `javax.activation:javax.activation-api`
+- No version changes (inherited from BOM)
+
+### 2. Java Code Import Updates
+
+**Search Pattern:** `javax.xml.bind`
+**Replace With:** `jakarta.xml.bind`
+
+**Affected Classes (by import type):**
+
+#### JAXB Core Classes:
+- `javax.xml.bind.JAXBContext` → `jakarta.xml.bind.JAXBContext`
+- `javax.xml.bind.JAXBElement` → `jakarta.xml.bind.JAXBElement`
+- `javax.xml.bind.JAXBException` → `jakarta.xml.bind.JAXBException`
+- `javax.xml.bind.Marshaller` → `jakarta.xml.bind.Marshaller`
+- `javax.xml.bind.Unmarshaller` → `jakarta.xml.bind.Unmarshaller`
+- `javax.xml.bind.DataBindingException` → `jakarta.xml.bind.DataBindingException`
+- `javax.xml.bind.UnmarshalException` → `jakarta.xml.bind.UnmarshalException`
+
+#### JAXB Annotations:
+- `javax.xml.bind.annotation.*` → `jakarta.xml.bind.annotation.*`
+  - `@XmlElement`, `@XmlAttribute`, `@XmlRootElement`
+  - `@XmlAccessorType`, `@XmlAccessType`
+  - `@XmlElementWrapper`, `@XmlType`, `@XmlTransient`
+  - `@XmlSchema`, `@XmlNs`, `@XmlNsForm`
+  - `@XmlID`, `@XmlIDREF`, `@XmlSeeAlso`, `@XmlValue`
+
+#### JAXB Adapters:
+- `javax.xml.bind.annotation.adapters.XmlAdapter` → `jakarta.xml.bind.annotation.adapters.XmlAdapter`
+- `javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter` → `jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter`
+
+### 3. Module Update Order
+
+To minimize compilation errors, update in this order:
+
+1. **common-artifacts-model** (base classes)
+   - 3 files: `LongToStringAdapter.java`, `BaseDefinitionElementImpl.java`, `NamedDefinitionElementImpl.java`
+   - Also: `AbstractParser.java` (used by multiple parsers)
+
+2. **process-definition-model** (48 files)
+   - All impl classes under `org.bonitasoft.engine.bpm.*`
+   - 27 package-info.java files
+
+3. **business-object-model** (10+ files)
+   - `BusinessObjectModelConverter.java` (critical converter)
+   - Model classes
+   - Test helpers
+
+4. **Remaining modules** (can be done in parallel):
+   - organization-model (11 files)
+   - connector-model (8 files)
+   - application-model (7 files)
+   - bdm-access-control-model (6 files)
+   - profile-model (5 files)
+   - form-mapping-model (4 files)
+   - business-archive (4 files)
+
+5. **Test files** (7 files across modules)
+
+### 4. Build Tool Verification
+
+**JAXB Maven Plugin:**
+- Current: `org.codehaus.mojo:jaxb2-maven-plugin:2.5.0`
+- Action: Verify compatibility with Jakarta, upgrade if needed
+- Alternative: Consider `org.jvnet.jaxb:jaxb-maven-plugin` for Jakarta support
+
+### 5. Post-Migration Validation
+
+1. **Compilation:** `./mvnw clean compile`
+2. **XSD Generation:** Verify XSD files are generated correctly in target directories
+3. **Unit Tests:** `./mvnw test`
+4. **Integration Tests:** `./mvnw verify`
+5. **Code Format:** `./mvnw spotless:apply`
+6. **Coverage Report:** Check coverage metrics remain unchanged
+
+## Risks and Constraints
+
+### Risks
+
+1. **API Compatibility Risk: LOW**
+   - Jakarta XML Binding 3.x maintains full API compatibility
+   - Only namespace changes, no behavioral changes
+
+2. **Build Tool Risk: MEDIUM**
+   - jaxb2-maven-plugin may not support Jakarta out of the box
+   - Mitigation: Upgrade plugin or switch to Jakarta-aware alternative
+
+3. **Downstream Consumer Risk: HIGH**
+   - Projects depending on these artifacts must also migrate
+   - Breaking change for consumers still on javax
+   - Mitigation: Version bump (1.3.0 → 2.0.0) to signal breaking change
+
+4. **XSD Namespace Risk: LOW**
+   - Generated XSD schemas should remain unchanged
+   - XML namespaces are independent of Java package names
+
+### Constraints
+
+1. **No Functional Changes**
+   - Pure namespace migration only
+   - No API changes, no behavioral changes
+   - All existing tests must pass without modification
+
+2. **Atomic Migration**
+   - Cannot partially migrate (mixing javax and jakarta will cause conflicts)
+   - Must update all modules together
+
+3. **Version Compatibility**
+   - Requires Java 11+ (already required)
+   - Maven 3.6+ (already met with wrapper)
+
+4. **Backward Compatibility**
+   - This is a breaking change for consumers
+   - Requires semantic version bump (major or minor)
+
+## Dependencies to Update
+
+### Central BOM (`artifacts-model-dependencies/pom.xml`)
+```xml
+<!-- FROM -->
+<groupId>javax.xml.bind</groupId>
+<artifactId>jaxb-api</artifactId>
+<version>2.3.1</version>
+
+<!-- TO -->
+<groupId>jakarta.xml.bind</groupId>
+<artifactId>jakarta.xml.bind-api</artifactId>
+<version>3.0.1</version>
+
+<!-- FROM -->
+<groupId>org.glassfish.jaxb</groupId>
+<artifactId>jaxb-runtime</artifactId>
+<version>2.3.1</version>
+
+<!-- TO -->
+<groupId>org.glassfish.jaxb</groupId>
+<artifactId>jaxb-runtime</artifactId>
+<version>3.0.2</version>
+```
+
+### Module POMs (11 modules)
+Update `<groupId>` and `<artifactId>` only:
+- `javax.xml.bind:jaxb-api` → `jakarta.xml.bind:jakarta.xml.bind-api`
+
+Modules requiring updates:
+1. common-artifacts-model
+2. process-definition-model
+3. business-object-model
+4. connector-model
+5. profile-model
+6. organization-model
+7. application-model
+8. bdm-access-control-model
+9. business-archive
+10. form-mapping-model
+
+### Keep As-Is
+- `com.sun.activation:jakarta.activation:1.2.2` (already Jakarta)
+- `org.glassfish.hk2:osgi-resource-locator:2.4.0` (not affected)
+
+## Testing Strategy
+
+### Unit Tests
+- All existing unit tests must pass
+- No test modifications needed (API-compatible)
+- Focus on marshalling/unmarshalling tests
+
+### Integration Tests
+- Verify end-to-end serialization/deserialization
+- Check XSD generation in each module
+
+### Regression Tests
+- Compare generated XSD files before/after migration
+- Verify XML output format remains identical
+
+### Key Test Files to Monitor:
+1. `FormMappingModelMarshallerTest.java`
+2. `BusinessObjectModelConverterTest.java`
+3. `BDMAccessControlParserTest.java`
+4. `ApplicationNodeContainerConverterTest.java`
+5. All parser tests in organization-model and profile-model
+
+## Timeline
+
+This is a straightforward namespace migration with no expected functional issues.
+
+**Estimated Effort:**
+- POM updates: ~1 hour
+- Java code updates: ~2 hours (with automated find-replace)
+- Testing & verification: ~2 hours
+- **Total: ~5 hours**
+
+## Consequences
+
+### Positive
+- Modern Jakarta EE alignment
+- Future-proof for Java ecosystem evolution
+- Enables adoption of Jakarta EE 9+ features
+- Maintains full API compatibility
+
+### Negative
+- Breaking change for downstream consumers
+- Requires coordinated migration across ecosystem
+- Version bump needed (suggest 2.0.0)
+
+### Neutral
+- No functional changes
+- No performance impact
+- Same XSD schemas
+
+## References
+
+- [Jakarta XML Binding Specification](https://jakarta.ee/specifications/xml-binding/3.0/)
+- [Jakarta EE 9 Migration Guide](https://eclipse-ee4j.github.io/jakartaee-platform/jakartaee9/JakartaEE9ReleasePlan)
+- [JAXB Maven Plugin Jakarta Support](https://github.com/mojohaus/jaxb2-maven-plugin)
+
+## Next Steps
+
+1. Get approval for migration plan
+2. Create feature branch: `refactor/xml-bind/move-from-javax-to-jakarta` (already exists)
+3. Update dependencies in BOM
+4. Update Java imports across all modules
+5. Run full test suite
+6. Update CLAUDE.md to reflect Jakarta usage
+7. Create PR with detailed migration notes

--- a/doc/adr/javax-to-jakarta-migration-plan.md
+++ b/doc/adr/javax-to-jakarta-migration-plan.md
@@ -1,7 +1,13 @@
 # Architecture Decision Record: javax to jakarta XML Binding Migration
 
 ## Status
-Proposed
+Approved - In Progress
+
+## Decisions Made
+
+1. **Version Bump**: Migrate to version `2.0.0-SNAPSHOT` (major version bump to signal breaking change)
+2. **JAXB Maven Plugin**: Replace `org.codehaus.mojo:jaxb2-maven-plugin:2.5.0` with `org.jvnet.jaxb:jaxb-maven-plugin:4.0.8` (Jakarta-compatible)
+3. **Migration Approach**: Pilot migration first with `form-mapping-model` module, then full migration if successful
 
 ## Context
 
@@ -27,24 +33,36 @@ We need to migrate to:
 
 ## Decision
 
-We will migrate all `javax.xml.bind.*` imports to `jakarta.xml.bind.*` across the entire codebase in a single, atomic change.
+We will migrate all `javax.xml.bind.*` imports to `jakarta.xml.bind.*` across the entire codebase, starting with a pilot migration to validate the approach.
 
 ### Migration Strategy
 
-#### Phase 1: Dependency Updates (Maven POMs)
-1. Update BOM (`artifacts-model-dependencies/pom.xml`) first
-2. All other modules inherit from BOM
-3. No version changes needed in individual module POMs
+#### Phase 0: Version Bump
+1. Bump project version from `1.3.0-SNAPSHOT` to `2.0.0-SNAPSHOT` in root POM
+2. This signals a breaking change to downstream consumers
 
-#### Phase 2: Java Code Updates
-1. Update `common-artifacts-model` first (base classes)
+#### Phase 1: Pilot Migration (form-mapping-model)
+1. Update BOM with Jakarta dependencies
+2. Update JAXB Maven plugin to Jakarta-compatible version
+3. Migrate `form-mapping-model` module (4 files)
+4. Test compilation, XSD generation, and unit tests
+5. Validate approach before full migration
+
+**Rationale for form-mapping-model as pilot:**
+- Small scope (4 Java files + 1 test)
+- Complete JAXB usage (marshaller, models, annotations)
+- Uses jaxb2-maven-plugin for XSD generation
+- Has test coverage to validate functionality
+
+#### Phase 2: Full Migration (if pilot succeeds)
+1. Update `common-artifacts-model` (base classes)
 2. Update remaining modules in dependency order
 3. Use automated find-replace for consistency
 
-#### Phase 3: Testing & Validation
+#### Phase 3: Final Validation
 1. Run full build to verify compilation
-2. Execute test suite to verify functionality
-3. Verify XSD generation still works correctly
+2. Execute complete test suite
+3. Verify XSD generation in all modules
 
 ## Implementation Plan
 
@@ -143,12 +161,42 @@ To minimize compilation errors, update in this order:
 
 5. **Test files** (7 files across modules)
 
-### 4. Build Tool Verification
+### 4. JAXB Maven Plugin Migration
 
-**JAXB Maven Plugin:**
-- Current: `org.codehaus.mojo:jaxb2-maven-plugin:2.5.0`
-- Action: Verify compatibility with Jakarta, upgrade if needed
-- Alternative: Consider `org.jvnet.jaxb:jaxb-maven-plugin` for Jakarta support
+**Current Plugin:**
+- `org.codehaus.mojo:jaxb2-maven-plugin:2.5.0`
+- Does NOT support Jakarta XML Binding (generates javax.xml.bind imports)
+
+**New Plugin:**
+- `org.jvnet.jaxb:jaxb-maven-plugin:4.0.8`
+- Full Jakarta XML Binding 4.x support
+- Active development by highsource/jaxb-tools project
+- Direct replacement with similar configuration
+
+**Research Sources:**
+- [highsource/jaxb-tools GitHub](https://github.com/highsource/jaxb-tools) - Official plugin repository
+- [Jakarta JAXB Issue #138](https://github.com/mojohaus/jaxb2-maven-plugin/issues/138) - MojoHaus Jakarta support discussion
+- [Jakarta XML Binding Documentation](https://eclipse-ee4j.github.io/jaxb-ri/4.0.3/docs/ch04.html) - Official Jakarta docs
+- [Stack Overflow: JAXB 3.0 Maven Plugin](https://stackoverflow.com/questions/66580186/is-there-any-maven-plugin-for-jaxb-3-0-jakarta-ee-9) - Community guidance
+
+**Configuration Changes:**
+```xml
+<!-- FROM -->
+<plugin>
+  <groupId>org.codehaus.mojo</groupId>
+  <artifactId>jaxb2-maven-plugin</artifactId>
+  <version>2.5.0</version>
+</plugin>
+
+<!-- TO -->
+<plugin>
+  <groupId>org.jvnet.jaxb</groupId>
+  <artifactId>jaxb-maven-plugin</artifactId>
+  <version>4.0.8</version>
+</plugin>
+```
+
+Most configuration options remain compatible between the plugins.
 
 ### 5. Post-Migration Validation
 

--- a/doc/adr/javax-to-jakarta-migration-plan.md
+++ b/doc/adr/javax-to-jakarta-migration-plan.md
@@ -1,13 +1,21 @@
 # Architecture Decision Record: javax to jakarta XML Binding Migration
 
 ## Status
-Approved - In Progress
+✅ Completed
 
 ## Decisions Made
 
-1. **Version Bump**: Migrate to version `2.0.0-SNAPSHOT` (major version bump to signal breaking change)
-2. **JAXB Maven Plugin**: Replace `org.codehaus.mojo:jaxb2-maven-plugin:2.5.0` with `org.jvnet.jaxb:jaxb-maven-plugin:4.0.8` (Jakarta-compatible)
-3. **Migration Approach**: Pilot migration first with `form-mapping-model` module, then full migration if successful
+1. **Version Bump**: Migrate to version `2.0.0-SNAPSHOT` (major version bump to signal breaking change) ✅
+2. **JAXB Maven Plugin**: Upgrade `org.codehaus.mojo:jaxb2-maven-plugin` from `2.5.0` to `3.1.0` (Jakarta-compatible) ✅
+3. **Migration Approach**: Pilot migration first with `form-mapping-model` module, then full migration if successful ✅
+
+## Implementation Results
+
+- **All 10 modules** successfully migrated to Jakarta EE
+- **All 305 tests passing** (0 failures, 0 errors, 0 skipped)
+- **XSD schemas verified** - byte-identical before and after migration
+- **Commit**: `496eee2` - "refactor: complete migration from javax.xml.bind to jakarta.xml.bind"
+- **Pull Request**: #181 on `develop` branch
 
 ## Context
 
@@ -168,35 +176,46 @@ To minimize compilation errors, update in this order:
 - Does NOT support Jakarta XML Binding (generates javax.xml.bind imports)
 
 **New Plugin:**
-- `org.jvnet.jaxb:jaxb-maven-plugin:4.0.8`
-- Full Jakarta XML Binding 4.x support
-- Active development by highsource/jaxb-tools project
-- Direct replacement with similar configuration
+- `org.codehaus.mojo:jaxb2-maven-plugin:3.1.0`
+- **Full Jakarta XML Binding 3.0 support** ✅
+- Uses `jakarta.xml.bind-api:3.0.0` internally
+- Maintained by MojoHaus community
+- **Verified to generate identical XSD schemas** (byte-for-byte match)
 
-**Research Sources:**
-- [highsource/jaxb-tools GitHub](https://github.com/highsource/jaxb-tools) - Official plugin repository
-- [Jakarta JAXB Issue #138](https://github.com/mojohaus/jaxb2-maven-plugin/issues/138) - MojoHaus Jakarta support discussion
-- [Jakarta XML Binding Documentation](https://eclipse-ee4j.github.io/jaxb-ri/4.0.3/docs/ch04.html) - Official Jakarta docs
-- [Stack Overflow: JAXB 3.0 Maven Plugin](https://stackoverflow.com/questions/66580186/is-there-any-maven-plugin-for-jaxb-3-0-jakarta-ee-9) - Community guidance
+**Decision Rationale:**
+After testing, `org.codehaus.mojo:jaxb2-maven-plugin:3.1.0` was confirmed to:
+- Support Jakarta EE (JAXB 3.0+) starting from version 3.0.0
+- Generate byte-identical XSD schemas compared to the javax-based predecessor
+- Pass all 305 tests successfully
+- Maintain backward compatibility for XSD consumers
+- Require no configuration changes (drop-in replacement)
+
+**Alternative Considered:**
+- `org.jvnet.jaxb:jaxb-maven-plugin:4.0.8` (JAXB 4.0, more advanced features)
+- Not required for our use case - the MojoHaus plugin meets all requirements
 
 **Configuration Changes:**
 ```xml
+<!-- Root pom.xml property update -->
 <!-- FROM -->
-<plugin>
-  <groupId>org.codehaus.mojo</groupId>
-  <artifactId>jaxb2-maven-plugin</artifactId>
-  <version>2.5.0</version>
-</plugin>
+<jaxb2-maven-plugin.version>2.5.0</jaxb2-maven-plugin.version>
 
 <!-- TO -->
-<plugin>
-  <groupId>org.jvnet.jaxb</groupId>
-  <artifactId>jaxb-maven-plugin</artifactId>
-  <version>4.0.8</version>
-</plugin>
+<jaxb2-maven-plugin.version>3.1.0</jaxb2-maven-plugin.version>
+
+<!-- No changes needed in module POMs - they inherit from parent -->
 ```
 
-Most configuration options remain compatible between the plugins.
+**Research Sources:**
+- [MojoHaus JAXB2 Plugin Dependencies](https://www.mojohaus.org/jaxb2-maven-plugin/Documentation/v3.1.0/dependencies.html)
+- [Jakarta JAXB Issue #138](https://github.com/mojohaus/jaxb2-maven-plugin/issues/138) - Jakarta support discussion
+- [MojoHaus Releases](https://github.com/mojohaus/jaxb2-maven-plugin/releases) - Version 3.0.0 introduced JAXB 3 support
+
+**XSD Validation:**
+All 9 generated XSD files verified to be byte-identical before and after migration using:
+- Binary diff comparison (`diff -r`)
+- SHA256 checksum verification
+- See XSD comparison report for full details
 
 ### 5. Post-Migration Validation
 

--- a/docs/001-migration-to-jakarta_dependency-comparison.md
+++ b/docs/001-migration-to-jakarta_dependency-comparison.md
@@ -1,0 +1,109 @@
+# Dependency Tree Comparison: javax.xml.bind → jakarta.xml.bind Migration
+
+## Module: bonita-business-archive
+
+### BEFORE Migration (commit 3315bcb)
+```
+org.bonitasoft.engine:bonita-business-archive:jar:1.3.0-SNAPSHOT
++- javax.xml.bind:jaxb-api:jar:2.3.1:compile
++- org.glassfish.jaxb:jaxb-runtime:jar:2.3.1:compile
+|  +- org.glassfish.jaxb:txw2:jar:2.3.1:compile
+|  +- com.sun.istack:istack-commons-runtime:jar:3.0.7:compile
+|  +- org.jvnet.staxex:stax-ex:jar:1.8:compile
+|  \- com.sun.xml.fastinfoset:FastInfoset:jar:1.2.15:compile
++- com.sun.activation:jakarta.activation:jar:1.2.2:runtime
+```
+
+### AFTER Migration (commit fa0bc4c)
+```
+org.bonitasoft.engine:bonita-business-archive:jar:2.0.0-SNAPSHOT
++- jakarta.xml.bind:jakarta.xml.bind-api:jar:3.0.1:compile
++- org.glassfish.jaxb:jaxb-runtime:jar:3.0.2:compile
+|  \- org.glassfish.jaxb:jaxb-core:jar:3.0.2:compile
+|     +- org.glassfish.jaxb:txw2:jar:3.0.2:compile
+|     \- com.sun.istack:istack-commons-runtime:jar:4.0.1:compile
++- com.sun.activation:jakarta.activation:jar:2.0.1:runtime
+```
+
+## Key Changes
+
+### 1. JAXB API Migration
+**Before:** `javax.xml.bind:jaxb-api:2.3.1` (Java EE)
+**After:** `jakarta.xml.bind:jakarta.xml.bind-api:3.0.1` (Jakarta EE 9+)
+- GroupId changed from `javax.xml.bind` to `jakarta.xml.bind`
+- ArtifactId changed from `jaxb-api` to `jakarta.xml.bind-api`
+- Version upgraded from 2.3.1 to 3.0.1
+
+### 2. JAXB Runtime Upgrade
+**Before:** `org.glassfish.jaxb:jaxb-runtime:2.3.1`
+**After:** `org.glassfish.jaxb:jaxb-runtime:3.0.2`
+- Version upgraded from 2.3.1 to 3.0.2
+- Dependency tree simplified:
+  - ✅ Removed: `org.jvnet.staxex:stax-ex:1.8`
+  - ✅ Removed: `com.sun.xml.fastinfoset:FastInfoset:1.2.15`
+  - ✅ Added: `org.glassfish.jaxb:jaxb-core:3.0.2` (consolidated dependency)
+
+### 3. Supporting Libraries Updated
+**istack-commons-runtime:**
+- Before: `com.sun.istack:istack-commons-runtime:3.0.7`
+- After: `com.sun.istack:istack-commons-runtime:4.0.1`
+
+**txw2:**
+- Before: `org.glassfish.jaxb:txw2:2.3.1` (direct)
+- After: `org.glassfish.jaxb:txw2:3.0.2` (via jaxb-core)
+
+### 4. Jakarta Activation - CRITICAL FIX
+**Before:** `com.sun.activation:jakarta.activation:1.2.2`
+**After:** `com.sun.activation:jakarta.activation:2.0.1`
+- Version 1.2.2 still uses javax packages internally
+- Version 2.0.1 is the first release with proper Jakarta EE 9+ support
+- This was crucial for the migration to work correctly
+
+### 5. Version Bump
+**Parent POM version:**
+- Before: 1.3.0-SNAPSHOT
+- After: 2.0.0-SNAPSHOT
+- Major version bump signifies breaking API change (javax → jakarta namespace)
+
+## Benefits of Migration
+
+### 1. Cleaner Dependency Tree
+- Removed 2 legacy dependencies (stax-ex, FastInfoset)
+- Simplified transitive dependencies through jaxb-core consolidation
+
+### 2. Modern Jakarta EE Stack
+- Aligned with Jakarta EE 9+ specifications
+- Future-proof for Java 17+ and beyond
+- Better maintained and supported ecosystem
+
+### 3. No javax.activation Artifacts
+- Before: Had to explicitly exclude `javax.activation:javax.activation-api` 
+- After: No exclusions needed - Jakarta JAXB 3.x natively depends on jakarta.activation
+
+### 4. Performance & Compatibility
+- Jakarta JAXB 3.x is optimized for modern JVMs
+- Better compatibility with Jakarta EE application servers
+- Supports Java 11+ features
+
+## Migration Impact Summary
+
+| Aspect | Before | After | Status |
+|--------|--------|-------|--------|
+| **Namespace** | `javax.xml.bind.*` | `jakarta.xml.bind.*` | ✅ Migrated |
+| **API Version** | JAXB 2.3.1 | JAXB 3.0.1 | ✅ Upgraded |
+| **Runtime Version** | 2.3.1 | 3.0.2 | ✅ Upgraded |
+| **Activation** | 1.2.2 (javax) | 2.0.1 (jakarta) | ✅ Fixed |
+| **Exclusions** | Required | None needed | ✅ Simplified |
+| **Transitive Deps** | 6 (stax-ex, FastInfoset, etc.) | 4 (consolidated) | ✅ Cleaned |
+| **Tests** | 305 passing | 305 passing | ✅ All pass |
+| **Files Changed** | - | 154 files | ✅ Complete |
+| **Lines Changed** | - | +598/-744 | ✅ Net reduction |
+
+## Verification
+
+* ✅ All 10 modules successfully migrated
+* ✅ All 305 tests passing (0 failures, 0 errors, 0 skipped)
+* ✅ XSD generation working correctly
+* ✅ No javax.activation artifacts in classpath
+* ✅ Build completes successfully
+* ✅ Dependency tree clean and simplified

--- a/form-mapping-model/pom.xml
+++ b/form-mapping-model/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.bonitasoft.engine</groupId>
     <artifactId>bonita-artifacts-model-parent</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>bonita-form-mapping-model</artifactId>
   <name>Bonita Form Mapping Model</name>
@@ -22,29 +22,16 @@
   </dependencyManagement>
   <dependencies>
     <dependency>
-      <groupId>javax.xml.bind</groupId>
-      <artifactId>jaxb-api</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>javax.activation</groupId>
-          <artifactId>javax.activation-api</artifactId>
-        </exclusion>
-      </exclusions>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jaxb</groupId>
       <artifactId>jaxb-runtime</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>javax.activation</groupId>
-          <artifactId>javax.activation-api</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.sun.activation</groupId>
       <artifactId>jakarta.activation</artifactId>
-      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.glassfish.hk2</groupId>

--- a/form-mapping-model/src/main/java/org/bonitasoft/engine/bpm/bar/form/model/FormMappingDefinition.java
+++ b/form-mapping-model/src/main/java/org/bonitasoft/engine/bpm/bar/form/model/FormMappingDefinition.java
@@ -17,12 +17,12 @@ import java.io.Serializable;
 import java.util.Objects;
 import java.util.StringJoiner;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-
 import org.bonitasoft.engine.form.FormMappingTarget;
 import org.bonitasoft.engine.form.FormMappingType;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 public class FormMappingDefinition implements Serializable {

--- a/form-mapping-model/src/main/java/org/bonitasoft/engine/bpm/bar/form/model/FormMappingModel.java
+++ b/form-mapping-model/src/main/java/org/bonitasoft/engine/bpm/bar/form/model/FormMappingModel.java
@@ -19,11 +19,11 @@ import java.util.List;
 import java.util.Objects;
 import java.util.StringJoiner;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlElementWrapper;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlElementWrapper;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/form-mapping-model/src/main/java/org/bonitasoft/engine/bpm/bar/form/model/package-info.java
+++ b/form-mapping-model/src/main/java/org/bonitasoft/engine/bpm/bar/form/model/package-info.java
@@ -16,5 +16,5 @@
 })
 package org.bonitasoft.engine.bpm.bar.form.model;
 
-import javax.xml.bind.annotation.XmlNs;
-import javax.xml.bind.annotation.XmlSchema;
+import jakarta.xml.bind.annotation.XmlNs;
+import jakarta.xml.bind.annotation.XmlSchema;

--- a/form-mapping-model/src/main/java/org/bonitasoft/engine/bpm/form/FormMappingModelMarshaller.java
+++ b/form-mapping-model/src/main/java/org/bonitasoft/engine/bpm/form/FormMappingModelMarshaller.java
@@ -20,11 +20,6 @@ import java.net.URL;
 import java.util.Optional;
 
 import javax.xml.XMLConstants;
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBElement;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Marshaller;
-import javax.xml.bind.Unmarshaller;
 import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
@@ -32,6 +27,12 @@ import javax.xml.validation.SchemaFactory;
 import org.bonitasoft.engine.bpm.bar.form.model.FormMappingModel;
 import org.glassfish.hk2.osgiresourcelocator.ResourceFinder;
 import org.xml.sax.SAXException;
+
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBElement;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Marshaller;
+import jakarta.xml.bind.Unmarshaller;
 
 public class FormMappingModelMarshaller {
 

--- a/form-mapping-model/src/main/java/org/bonitasoft/engine/form/package-info.java
+++ b/form-mapping-model/src/main/java/org/bonitasoft/engine/form/package-info.java
@@ -16,5 +16,5 @@
 })
 package org.bonitasoft.engine.form;
 
-import javax.xml.bind.annotation.XmlNs;
-import javax.xml.bind.annotation.XmlSchema;
+import jakarta.xml.bind.annotation.XmlNs;
+import jakarta.xml.bind.annotation.XmlSchema;

--- a/form-mapping-model/src/test/java/org/bonitasoft/engine/bpm/form/FormMappingModelMarshallerTest.java
+++ b/form-mapping-model/src/test/java/org/bonitasoft/engine/bpm/form/FormMappingModelMarshallerTest.java
@@ -19,13 +19,13 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.nio.charset.StandardCharsets;
 
-import javax.xml.bind.JAXBException;
-
 import org.bonitasoft.engine.bpm.bar.form.model.FormMappingDefinition;
 import org.bonitasoft.engine.bpm.bar.form.model.FormMappingModel;
 import org.bonitasoft.engine.form.FormMappingTarget;
 import org.bonitasoft.engine.form.FormMappingType;
 import org.junit.jupiter.api.Test;
+
+import jakarta.xml.bind.JAXBException;
 
 class FormMappingModelMarshallerTest {
 

--- a/organization-model/pom.xml
+++ b/organization-model/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.bonitasoft.engine</groupId>
     <artifactId>bonita-artifacts-model-parent</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>bonita-organization-model</artifactId>
   <name>Bonita Organization Model</name>
@@ -26,24 +26,12 @@
       <artifactId>bonita-common-artifacts-model</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.xml.bind</groupId>
-      <artifactId>jaxb-api</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>javax.activation</groupId>
-          <artifactId>javax.activation-api</artifactId>
-        </exclusion>
-      </exclusions>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jaxb</groupId>
       <artifactId>jaxb-runtime</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>javax.activation</groupId>
-          <artifactId>javax.activation-api</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.sun.activation</groupId>

--- a/organization-model/src/main/java/org/bonitasoft/engine/identity/OrganizationParser.java
+++ b/organization-model/src/main/java/org/bonitasoft/engine/identity/OrganizationParser.java
@@ -19,16 +19,17 @@ import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
 import javax.xml.XMLConstants;
-import javax.xml.bind.DataBindingException;
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Marshaller;
-import javax.xml.bind.Unmarshaller;
 import javax.xml.validation.SchemaFactory;
 
 import org.bonitasoft.engine.identity.xml.Organization;
 import org.glassfish.hk2.osgiresourcelocator.ResourceFinder;
 import org.xml.sax.SAXException;
+
+import jakarta.xml.bind.DataBindingException;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Marshaller;
+import jakarta.xml.bind.Unmarshaller;
 
 /**
  * @author Baptiste Mesta

--- a/organization-model/src/main/java/org/bonitasoft/engine/identity/xml/ExportedContactInfo.java
+++ b/organization-model/src/main/java/org/bonitasoft/engine/identity/xml/ExportedContactInfo.java
@@ -13,10 +13,10 @@
  **/
 package org.bonitasoft.engine.identity.xml;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlType;
 
 /**
  * @author Baptiste Mesta

--- a/organization-model/src/main/java/org/bonitasoft/engine/identity/xml/ExportedCustomUserInfoDefinition.java
+++ b/organization-model/src/main/java/org/bonitasoft/engine/identity/xml/ExportedCustomUserInfoDefinition.java
@@ -16,9 +16,9 @@ package org.bonitasoft.engine.identity.xml;
 import java.util.Objects;
 import java.util.StringJoiner;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
 
 /**
  * @author Baptiste Mesta

--- a/organization-model/src/main/java/org/bonitasoft/engine/identity/xml/ExportedCustomUserInfoValue.java
+++ b/organization-model/src/main/java/org/bonitasoft/engine/identity/xml/ExportedCustomUserInfoValue.java
@@ -16,9 +16,9 @@ package org.bonitasoft.engine.identity.xml;
 import java.util.Objects;
 import java.util.StringJoiner;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
 
 /**
  * @author Elias Ricken de Medeiros

--- a/organization-model/src/main/java/org/bonitasoft/engine/identity/xml/ExportedGroup.java
+++ b/organization-model/src/main/java/org/bonitasoft/engine/identity/xml/ExportedGroup.java
@@ -16,10 +16,10 @@ package org.bonitasoft.engine.identity.xml;
 import java.util.Objects;
 import java.util.StringJoiner;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
 
 /**
  * @author Baptiste Mesta

--- a/organization-model/src/main/java/org/bonitasoft/engine/identity/xml/ExportedRole.java
+++ b/organization-model/src/main/java/org/bonitasoft/engine/identity/xml/ExportedRole.java
@@ -17,10 +17,10 @@ import java.io.Serializable;
 import java.util.Objects;
 import java.util.StringJoiner;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 public class ExportedRole implements Serializable {

--- a/organization-model/src/main/java/org/bonitasoft/engine/identity/xml/ExportedUser.java
+++ b/organization-model/src/main/java/org/bonitasoft/engine/identity/xml/ExportedUser.java
@@ -17,14 +17,14 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlElementWrapper;
-import javax.xml.bind.annotation.XmlType;
-
 import org.bonitasoft.engine.identity.ContactData;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlElementWrapper;
+import jakarta.xml.bind.annotation.XmlType;
 
 /**
  * @author Emmanuel Duchastenier

--- a/organization-model/src/main/java/org/bonitasoft/engine/identity/xml/ExportedUserMembership.java
+++ b/organization-model/src/main/java/org/bonitasoft/engine/identity/xml/ExportedUserMembership.java
@@ -16,9 +16,9 @@ package org.bonitasoft.engine.identity.xml;
 import java.util.Objects;
 import java.util.StringJoiner;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
 
 /**
  * @author Baptiste Mesta

--- a/organization-model/src/main/java/org/bonitasoft/engine/identity/xml/ExportedUserPassword.java
+++ b/organization-model/src/main/java/org/bonitasoft/engine/identity/xml/ExportedUserPassword.java
@@ -13,10 +13,10 @@
  **/
 package org.bonitasoft.engine.identity.xml;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlValue;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlValue;
 
 /**
  * @author Baptiste Mesta

--- a/organization-model/src/main/java/org/bonitasoft/engine/identity/xml/MetaData.java
+++ b/organization-model/src/main/java/org/bonitasoft/engine/identity/xml/MetaData.java
@@ -13,9 +13,9 @@
  **/
 package org.bonitasoft.engine.identity.xml;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
 
 /**
  * only use in xml serialization for backward compatibility

--- a/organization-model/src/main/java/org/bonitasoft/engine/identity/xml/Organization.java
+++ b/organization-model/src/main/java/org/bonitasoft/engine/identity/xml/Organization.java
@@ -16,11 +16,11 @@ package org.bonitasoft.engine.identity.xml;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlElementWrapper;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlElementWrapper;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 /**
  * @author Baptiste Mesta

--- a/organization-model/src/main/java/org/bonitasoft/engine/identity/xml/package-info.java
+++ b/organization-model/src/main/java/org/bonitasoft/engine/identity/xml/package-info.java
@@ -21,5 +21,5 @@
         @XmlNs(prefix = "organization", namespaceURI = "http://documentation.bonitasoft.com/organization-xml-schema/1.1") })
 package org.bonitasoft.engine.identity.xml;
 
-import javax.xml.bind.annotation.XmlNs;
-import javax.xml.bind.annotation.XmlSchema;
+import jakarta.xml.bind.annotation.XmlNs;
+import jakarta.xml.bind.annotation.XmlSchema;

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.bonitasoft.engine</groupId>
   <artifactId>bonita-artifacts-model-parent</artifactId>
-  <version>1.3.0-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Bonita Artifacts Model Aggregator</name>
   <description>This module is the aggregator module</description>
@@ -74,7 +74,7 @@
     <flatten-maven-plugin.version>1.6.0</flatten-maven-plugin.version>
     <build-helper-maven-plugin.version>3.6.1</build-helper-maven-plugin.version>
     <spotless-maven-plugin.version>2.46.1</spotless-maven-plugin.version>
-    <jaxb2-maven-plugin.version>2.5.0</jaxb2-maven-plugin.version>
+    <jaxb2-maven-plugin.version>3.1.0</jaxb2-maven-plugin.version>
     <groovy-maven-plugin.version>2.1.1</groovy-maven-plugin.version>
     <groovy.version>3.0.25</groovy.version>
     <!-- Spotless resources location -->

--- a/process-definition-model/pom.xml
+++ b/process-definition-model/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.bonitasoft.engine</groupId>
     <artifactId>bonita-artifacts-model-parent</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>bonita-process-definition-model</artifactId>
   <name>Bonita Process Definition Model</name>
@@ -26,14 +26,8 @@
       <artifactId>bonita-common-artifacts-model</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.xml.bind</groupId>
-      <artifactId>jaxb-api</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>javax.activation</groupId>
-          <artifactId>javax.activation-api</artifactId>
-        </exclusion>
-      </exclusions>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
     </dependency>
     <dependency>
       <groupId>com.sun.activation</groupId>

--- a/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/actor/impl/ActorDefinitionImpl.java
+++ b/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/actor/impl/ActorDefinitionImpl.java
@@ -15,13 +15,13 @@ package org.bonitasoft.engine.bpm.actor.impl;
 
 import java.util.Objects;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-
 import org.bonitasoft.engine.bpm.actor.ActorDefinition;
 import org.bonitasoft.engine.bpm.internal.BaseDefinitionElementImpl;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
 
 /**
  * @author Matthieu Chaffotte

--- a/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/actor/impl/package-info.java
+++ b/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/actor/impl/package-info.java
@@ -12,10 +12,10 @@
  * Floor, Boston, MA 02110-1301, USA.
  **/
 @XmlSchema(namespace = NAMESPACE, elementFormDefault = XmlNsForm.UNSET, xmlns = {
-        @javax.xml.bind.annotation.XmlNs(namespaceURI = NAMESPACE, prefix = "tns") })
+        @jakarta.xml.bind.annotation.XmlNs(namespaceURI = NAMESPACE, prefix = "tns") })
 package org.bonitasoft.engine.bpm.actor.impl;
 
 import static org.bonitasoft.engine.ProcessDefinitionNamespace.NAMESPACE;
 
-import javax.xml.bind.annotation.XmlNsForm;
-import javax.xml.bind.annotation.XmlSchema;
+import jakarta.xml.bind.annotation.XmlNsForm;
+import jakarta.xml.bind.annotation.XmlSchema;

--- a/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/businessdata/impl/BusinessDataDefinitionImpl.java
+++ b/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/businessdata/impl/BusinessDataDefinitionImpl.java
@@ -15,17 +15,16 @@ package org.bonitasoft.engine.bpm.businessdata.impl;
 
 import static org.bonitasoft.engine.expression.ExpressionBuilder.getNonNullCopy;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-
 import org.bonitasoft.engine.bpm.businessdata.BusinessDataDefinition;
 import org.bonitasoft.engine.bpm.internal.NamedDefinitionElementImpl;
 import org.bonitasoft.engine.bpm.process.ModelFinderVisitor;
 import org.bonitasoft.engine.expression.Expression;
 import org.bonitasoft.engine.expression.impl.ExpressionImpl;
 
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/businessdata/impl/package-info.java
+++ b/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/businessdata/impl/package-info.java
@@ -12,10 +12,10 @@
  * Floor, Boston, MA 02110-1301, USA.
  **/
 @XmlSchema(namespace = NAMESPACE, elementFormDefault = XmlNsForm.UNSET, xmlns = {
-        @javax.xml.bind.annotation.XmlNs(namespaceURI = NAMESPACE, prefix = "tns") })
+        @jakarta.xml.bind.annotation.XmlNs(namespaceURI = NAMESPACE, prefix = "tns") })
 package org.bonitasoft.engine.bpm.businessdata.impl;
 
 import static org.bonitasoft.engine.ProcessDefinitionNamespace.NAMESPACE;
 
-import javax.xml.bind.annotation.XmlNsForm;
-import javax.xml.bind.annotation.XmlSchema;
+import jakarta.xml.bind.annotation.XmlNsForm;
+import jakarta.xml.bind.annotation.XmlSchema;

--- a/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/connector/impl/ConnectorDefinitionImpl.java
+++ b/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/connector/impl/ConnectorDefinitionImpl.java
@@ -20,13 +20,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlElementWrapper;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
-
 import org.bonitasoft.engine.bpm.connector.ConnectorDefinition;
 import org.bonitasoft.engine.bpm.connector.ConnectorEvent;
 import org.bonitasoft.engine.bpm.connector.FailAction;
@@ -38,6 +31,12 @@ import org.bonitasoft.engine.expression.ExpressionBuilder;
 import org.bonitasoft.engine.operation.Operation;
 import org.bonitasoft.engine.operation.impl.OperationImpl;
 
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlElementWrapper;
+import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;

--- a/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/connector/impl/package-info.java
+++ b/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/connector/impl/package-info.java
@@ -12,10 +12,10 @@
  * Floor, Boston, MA 02110-1301, USA.
  **/
 @XmlSchema(namespace = NAMESPACE, elementFormDefault = XmlNsForm.UNSET, xmlns = {
-        @javax.xml.bind.annotation.XmlNs(namespaceURI = NAMESPACE, prefix = "tns") })
+        @jakarta.xml.bind.annotation.XmlNs(namespaceURI = NAMESPACE, prefix = "tns") })
 package org.bonitasoft.engine.bpm.connector.impl;
 
 import static org.bonitasoft.engine.ProcessDefinitionNamespace.NAMESPACE;
 
-import javax.xml.bind.annotation.XmlNsForm;
-import javax.xml.bind.annotation.XmlSchema;
+import jakarta.xml.bind.annotation.XmlNsForm;
+import jakarta.xml.bind.annotation.XmlSchema;

--- a/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/connector/package-info.java
+++ b/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/connector/package-info.java
@@ -12,10 +12,10 @@
  * Floor, Boston, MA 02110-1301, USA.
  **/
 @XmlSchema(namespace = NAMESPACE, elementFormDefault = XmlNsForm.UNSET, xmlns = {
-        @javax.xml.bind.annotation.XmlNs(namespaceURI = NAMESPACE, prefix = "tns") })
+        @jakarta.xml.bind.annotation.XmlNs(namespaceURI = NAMESPACE, prefix = "tns") })
 package org.bonitasoft.engine.bpm.connector;
 
 import static org.bonitasoft.engine.ProcessDefinitionNamespace.NAMESPACE;
 
-import javax.xml.bind.annotation.XmlNsForm;
-import javax.xml.bind.annotation.XmlSchema;
+import jakarta.xml.bind.annotation.XmlNsForm;
+import jakarta.xml.bind.annotation.XmlSchema;

--- a/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/context/ContextEntryImpl.java
+++ b/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/context/ContextEntryImpl.java
@@ -15,15 +15,14 @@ package org.bonitasoft.engine.bpm.context;
 
 import static org.bonitasoft.engine.expression.ExpressionBuilder.getNonNullCopy;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-
 import org.bonitasoft.engine.bpm.process.ModelFinderVisitor;
 import org.bonitasoft.engine.expression.Expression;
 import org.bonitasoft.engine.expression.impl.ExpressionImpl;
 
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/context/package-info.java
+++ b/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/context/package-info.java
@@ -12,10 +12,10 @@
  * Floor, Boston, MA 02110-1301, USA.
  **/
 @XmlSchema(namespace = NAMESPACE, elementFormDefault = XmlNsForm.UNSET, xmlns = {
-        @javax.xml.bind.annotation.XmlNs(namespaceURI = NAMESPACE, prefix = "tns") })
+        @jakarta.xml.bind.annotation.XmlNs(namespaceURI = NAMESPACE, prefix = "tns") })
 package org.bonitasoft.engine.bpm.context;
 
 import static org.bonitasoft.engine.ProcessDefinitionNamespace.NAMESPACE;
 
-import javax.xml.bind.annotation.XmlNsForm;
-import javax.xml.bind.annotation.XmlSchema;
+import jakarta.xml.bind.annotation.XmlNsForm;
+import jakarta.xml.bind.annotation.XmlSchema;

--- a/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/contract/impl/ConstraintDefinitionImpl.java
+++ b/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/contract/impl/ConstraintDefinitionImpl.java
@@ -16,14 +16,13 @@ package org.bonitasoft.engine.bpm.contract.impl;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlElementWrapper;
-
 import org.bonitasoft.engine.bpm.contract.ConstraintDefinition;
 
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlElementWrapper;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 

--- a/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/contract/impl/ContractDefinitionImpl.java
+++ b/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/contract/impl/ContractDefinitionImpl.java
@@ -16,14 +16,13 @@ package org.bonitasoft.engine.bpm.contract.impl;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlElementWrapper;
-
 import org.bonitasoft.engine.bpm.contract.ConstraintDefinition;
 import org.bonitasoft.engine.bpm.contract.ContractDefinition;
 
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlElementWrapper;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/contract/impl/InputContainerDefinitionImpl.java
+++ b/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/contract/impl/InputContainerDefinitionImpl.java
@@ -16,14 +16,13 @@ package org.bonitasoft.engine.bpm.contract.impl;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlElementWrapper;
-
 import org.bonitasoft.engine.bpm.contract.InputContainerDefinition;
 import org.bonitasoft.engine.bpm.contract.InputDefinition;
 
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlElementWrapper;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/contract/impl/InputDefinitionImpl.java
+++ b/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/contract/impl/InputDefinitionImpl.java
@@ -17,13 +17,13 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-
 import org.bonitasoft.engine.bpm.contract.InputDefinition;
 import org.bonitasoft.engine.bpm.contract.Type;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
 
 /**
  * @author Matthieu Chaffotte

--- a/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/contract/impl/package-info.java
+++ b/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/contract/impl/package-info.java
@@ -12,10 +12,10 @@
  * Floor, Boston, MA 02110-1301, USA.
  **/
 @XmlSchema(namespace = NAMESPACE, elementFormDefault = XmlNsForm.UNSET, xmlns = {
-        @javax.xml.bind.annotation.XmlNs(namespaceURI = NAMESPACE, prefix = "tns") })
+        @jakarta.xml.bind.annotation.XmlNs(namespaceURI = NAMESPACE, prefix = "tns") })
 package org.bonitasoft.engine.bpm.contract.impl;
 
 import static org.bonitasoft.engine.ProcessDefinitionNamespace.NAMESPACE;
 
-import javax.xml.bind.annotation.XmlNsForm;
-import javax.xml.bind.annotation.XmlSchema;
+import jakarta.xml.bind.annotation.XmlNsForm;
+import jakarta.xml.bind.annotation.XmlSchema;

--- a/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/contract/package-info.java
+++ b/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/contract/package-info.java
@@ -12,10 +12,10 @@
  * Floor, Boston, MA 02110-1301, USA.
  **/
 @XmlSchema(namespace = NAMESPACE, elementFormDefault = XmlNsForm.UNSET, xmlns = {
-        @javax.xml.bind.annotation.XmlNs(namespaceURI = NAMESPACE, prefix = "tns") })
+        @jakarta.xml.bind.annotation.XmlNs(namespaceURI = NAMESPACE, prefix = "tns") })
 package org.bonitasoft.engine.bpm.contract;
 
 import static org.bonitasoft.engine.ProcessDefinitionNamespace.NAMESPACE;
 
-import javax.xml.bind.annotation.XmlNsForm;
-import javax.xml.bind.annotation.XmlSchema;
+import jakarta.xml.bind.annotation.XmlNsForm;
+import jakarta.xml.bind.annotation.XmlSchema;

--- a/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/data/impl/DataDefinitionImpl.java
+++ b/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/data/impl/DataDefinitionImpl.java
@@ -15,17 +15,16 @@ package org.bonitasoft.engine.bpm.data.impl;
 
 import static org.bonitasoft.engine.expression.ExpressionBuilder.getNonNullCopy;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-
 import org.bonitasoft.engine.bpm.data.DataDefinition;
 import org.bonitasoft.engine.bpm.internal.NamedDefinitionElementImpl;
 import org.bonitasoft.engine.bpm.process.ModelFinderVisitor;
 import org.bonitasoft.engine.expression.Expression;
 import org.bonitasoft.engine.expression.impl.ExpressionImpl;
 
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/data/impl/TextDataDefinitionImpl.java
+++ b/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/data/impl/TextDataDefinitionImpl.java
@@ -13,13 +13,12 @@
  **/
 package org.bonitasoft.engine.bpm.data.impl;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-
 import org.bonitasoft.engine.bpm.data.TextDataDefinition;
 import org.bonitasoft.engine.expression.Expression;
 
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/data/impl/XMLDataDefinitionImpl.java
+++ b/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/data/impl/XMLDataDefinitionImpl.java
@@ -13,13 +13,12 @@
  **/
 package org.bonitasoft.engine.bpm.data.impl;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-
 import org.bonitasoft.engine.bpm.data.XMLDataDefinition;
 import org.bonitasoft.engine.expression.Expression;
 
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/data/impl/package-info.java
+++ b/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/data/impl/package-info.java
@@ -12,10 +12,10 @@
  * Floor, Boston, MA 02110-1301, USA.
  **/
 @XmlSchema(namespace = NAMESPACE, elementFormDefault = XmlNsForm.UNSET, xmlns = {
-        @javax.xml.bind.annotation.XmlNs(namespaceURI = NAMESPACE, prefix = "tns") })
+        @jakarta.xml.bind.annotation.XmlNs(namespaceURI = NAMESPACE, prefix = "tns") })
 package org.bonitasoft.engine.bpm.data.impl;
 
 import static org.bonitasoft.engine.ProcessDefinitionNamespace.NAMESPACE;
 
-import javax.xml.bind.annotation.XmlNsForm;
-import javax.xml.bind.annotation.XmlSchema;
+import jakarta.xml.bind.annotation.XmlNsForm;
+import jakarta.xml.bind.annotation.XmlSchema;

--- a/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/document/impl/DocumentDefinitionImpl.java
+++ b/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/document/impl/DocumentDefinitionImpl.java
@@ -15,17 +15,16 @@ package org.bonitasoft.engine.bpm.document.impl;
 
 import static org.bonitasoft.engine.expression.ExpressionBuilder.getNonNullCopy;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-
 import org.bonitasoft.engine.bpm.document.DocumentDefinition;
 import org.bonitasoft.engine.bpm.internal.NamedDefinitionElementImpl;
 import org.bonitasoft.engine.bpm.process.ModelFinderVisitor;
 import org.bonitasoft.engine.expression.Expression;
 import org.bonitasoft.engine.expression.impl.ExpressionImpl;
 
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/document/impl/DocumentListDefinitionImpl.java
+++ b/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/document/impl/DocumentListDefinitionImpl.java
@@ -15,15 +15,15 @@ package org.bonitasoft.engine.bpm.document.impl;
 
 import static org.bonitasoft.engine.expression.ExpressionBuilder.getNonNullCopy;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-
 import org.bonitasoft.engine.bpm.document.DocumentListDefinition;
 import org.bonitasoft.engine.bpm.internal.NamedDefinitionElementImpl;
 import org.bonitasoft.engine.bpm.process.ModelFinderVisitor;
 import org.bonitasoft.engine.expression.Expression;
 import org.bonitasoft.engine.expression.impl.ExpressionImpl;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
 
 /**
  * @author Baptiste Mesta

--- a/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/document/impl/package-info.java
+++ b/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/document/impl/package-info.java
@@ -12,10 +12,10 @@
  * Floor, Boston, MA 02110-1301, USA.
  **/
 @XmlSchema(namespace = NAMESPACE, elementFormDefault = XmlNsForm.UNSET, xmlns = {
-        @javax.xml.bind.annotation.XmlNs(namespaceURI = NAMESPACE, prefix = "tns") })
+        @jakarta.xml.bind.annotation.XmlNs(namespaceURI = NAMESPACE, prefix = "tns") })
 package org.bonitasoft.engine.bpm.document.impl;
 
 import static org.bonitasoft.engine.ProcessDefinitionNamespace.NAMESPACE;
 
-import javax.xml.bind.annotation.XmlNsForm;
-import javax.xml.bind.annotation.XmlSchema;
+import jakarta.xml.bind.annotation.XmlNsForm;
+import jakarta.xml.bind.annotation.XmlSchema;

--- a/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/flownode/impl/internal/ActivityDefinitionImpl.java
+++ b/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/flownode/impl/internal/ActivityDefinitionImpl.java
@@ -19,13 +19,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlElementWrapper;
-import javax.xml.bind.annotation.XmlElements;
-import javax.xml.bind.annotation.XmlTransient;
-
 import org.bonitasoft.engine.bpm.ObjectSeeker;
 import org.bonitasoft.engine.bpm.businessdata.BusinessDataDefinition;
 import org.bonitasoft.engine.bpm.businessdata.impl.BusinessDataDefinitionImpl;
@@ -40,6 +33,12 @@ import org.bonitasoft.engine.bpm.process.ModelFinderVisitor;
 import org.bonitasoft.engine.operation.Operation;
 import org.bonitasoft.engine.operation.impl.OperationImpl;
 
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlElementWrapper;
+import jakarta.xml.bind.annotation.XmlElements;
+import jakarta.xml.bind.annotation.XmlTransient;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/flownode/impl/internal/CallActivityDefinitionImpl.java
+++ b/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/flownode/impl/internal/CallActivityDefinitionImpl.java
@@ -19,12 +19,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
-
 import org.bonitasoft.engine.bpm.flownode.CallActivityDefinition;
 import org.bonitasoft.engine.bpm.flownode.CallableElementType;
 import org.bonitasoft.engine.bpm.process.ModelFinderVisitor;
@@ -35,6 +29,11 @@ import org.bonitasoft.engine.operation.Operation;
 import org.bonitasoft.engine.operation.OperationBuilder;
 import org.bonitasoft.engine.operation.impl.OperationImpl;
 
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/flownode/impl/internal/CatchEventDefinitionImpl.java
+++ b/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/flownode/impl/internal/CatchEventDefinitionImpl.java
@@ -17,12 +17,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlTransient;
-
 import org.bonitasoft.engine.bpm.flownode.CatchErrorEventTriggerDefinition;
 import org.bonitasoft.engine.bpm.flownode.CatchEventDefinition;
 import org.bonitasoft.engine.bpm.flownode.CatchMessageEventTriggerDefinition;
@@ -30,6 +24,11 @@ import org.bonitasoft.engine.bpm.flownode.CatchSignalEventTriggerDefinition;
 import org.bonitasoft.engine.bpm.flownode.TimerEventTriggerDefinition;
 import org.bonitasoft.engine.bpm.process.ModelFinderVisitor;
 
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlTransient;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/flownode/impl/internal/CatchMessageEventTriggerDefinitionImpl.java
+++ b/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/flownode/impl/internal/CatchMessageEventTriggerDefinitionImpl.java
@@ -20,14 +20,14 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-
 import org.bonitasoft.engine.bpm.flownode.CatchMessageEventTriggerDefinition;
 import org.bonitasoft.engine.bpm.process.ModelFinderVisitor;
 import org.bonitasoft.engine.operation.Operation;
 import org.bonitasoft.engine.operation.impl.OperationImpl;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
 
 /**
  * @author Elias Ricken de Medeiros

--- a/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/flownode/impl/internal/CorrelationDefinitionImpl.java
+++ b/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/flownode/impl/internal/CorrelationDefinitionImpl.java
@@ -15,14 +15,14 @@ package org.bonitasoft.engine.bpm.flownode.impl.internal;
 
 import static org.bonitasoft.engine.expression.ExpressionBuilder.getNonNullCopy;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-
 import org.bonitasoft.engine.bpm.flownode.CorrelationDefinition;
 import org.bonitasoft.engine.bpm.process.ModelFinderVisitor;
 import org.bonitasoft.engine.expression.Expression;
 import org.bonitasoft.engine.expression.impl.ExpressionImpl;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
 
 /**
  * @author Baptiste Mesta

--- a/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/flownode/impl/internal/EndEventDefinitionImpl.java
+++ b/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/flownode/impl/internal/EndEventDefinitionImpl.java
@@ -17,14 +17,13 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-
 import org.bonitasoft.engine.bpm.flownode.EndEventDefinition;
 import org.bonitasoft.engine.bpm.flownode.TerminateEventTriggerDefinition;
 import org.bonitasoft.engine.bpm.flownode.ThrowErrorEventTriggerDefinition;
 
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/flownode/impl/internal/ErrorEventTriggerDefinitionImpl.java
+++ b/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/flownode/impl/internal/ErrorEventTriggerDefinitionImpl.java
@@ -13,14 +13,13 @@
  **/
 package org.bonitasoft.engine.bpm.flownode.impl.internal;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlTransient;
-
 import org.bonitasoft.engine.bpm.flownode.ErrorEventTriggerDefinition;
 import org.bonitasoft.engine.bpm.process.ModelFinderVisitor;
 
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlTransient;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;

--- a/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/flownode/impl/internal/EventDefinitionImpl.java
+++ b/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/flownode/impl/internal/EventDefinitionImpl.java
@@ -17,14 +17,13 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlTransient;
-
 import org.bonitasoft.engine.bpm.flownode.EventDefinition;
 import org.bonitasoft.engine.bpm.flownode.EventTriggerDefinition;
 import org.bonitasoft.engine.bpm.process.ModelFinderVisitor;
 
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlTransient;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 

--- a/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/flownode/impl/internal/FlowElementContainerDefinitionImpl.java
+++ b/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/flownode/impl/internal/FlowElementContainerDefinitionImpl.java
@@ -21,12 +21,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlElementWrapper;
-import javax.xml.bind.annotation.XmlElements;
-
 import org.bonitasoft.engine.bpm.NamedElement;
 import org.bonitasoft.engine.bpm.ObjectSeeker;
 import org.bonitasoft.engine.bpm.businessdata.BusinessDataDefinition;
@@ -56,6 +50,11 @@ import org.bonitasoft.engine.bpm.process.ModelFinderVisitor;
 import org.bonitasoft.engine.bpm.process.Visitable;
 import org.bonitasoft.engine.bpm.process.impl.internal.SubProcessDefinitionImpl;
 
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlElementWrapper;
+import jakarta.xml.bind.annotation.XmlElements;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.ToString;

--- a/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/flownode/impl/internal/FlowNodeDefinitionImpl.java
+++ b/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/flownode/impl/internal/FlowNodeDefinitionImpl.java
@@ -19,12 +19,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlIDREF;
-import javax.xml.bind.annotation.XmlTransient;
-
 import org.bonitasoft.engine.bpm.connector.ConnectorDefinition;
 import org.bonitasoft.engine.bpm.connector.impl.ConnectorDefinitionImpl;
 import org.bonitasoft.engine.bpm.flownode.FlowNodeDefinition;
@@ -34,6 +28,11 @@ import org.bonitasoft.engine.bpm.process.ModelFinderVisitor;
 import org.bonitasoft.engine.expression.Expression;
 import org.bonitasoft.engine.expression.impl.ExpressionImpl;
 
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlIDREF;
+import jakarta.xml.bind.annotation.XmlTransient;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/flownode/impl/internal/GatewayDefinitionImpl.java
+++ b/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/flownode/impl/internal/GatewayDefinitionImpl.java
@@ -15,12 +15,12 @@ package org.bonitasoft.engine.bpm.flownode.impl.internal;
 
 import java.util.Objects;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-
 import org.bonitasoft.engine.bpm.flownode.GatewayDefinition;
 import org.bonitasoft.engine.bpm.flownode.GatewayType;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
 
 /**
  * @author Feng Hui

--- a/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/flownode/impl/internal/HumanTaskDefinitionImpl.java
+++ b/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/flownode/impl/internal/HumanTaskDefinitionImpl.java
@@ -13,12 +13,6 @@
  **/
 package org.bonitasoft.engine.bpm.flownode.impl.internal;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlTransient;
-
 import org.bonitasoft.engine.bpm.flownode.HumanTaskDefinition;
 import org.bonitasoft.engine.bpm.process.ModelFinderVisitor;
 import org.bonitasoft.engine.bpm.userfilter.UserFilterDefinition;
@@ -26,6 +20,11 @@ import org.bonitasoft.engine.bpm.userfilter.impl.UserFilterDefinitionImpl;
 import org.bonitasoft.engine.expression.Expression;
 import org.bonitasoft.engine.expression.impl.ExpressionImpl;
 
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlTransient;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;

--- a/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/flownode/impl/internal/MessageEventTriggerDefinitionImpl.java
+++ b/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/flownode/impl/internal/MessageEventTriggerDefinitionImpl.java
@@ -18,16 +18,16 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlTransient;
-
 import org.bonitasoft.engine.bpm.flownode.CorrelationDefinition;
 import org.bonitasoft.engine.bpm.flownode.MessageEventTriggerDefinition;
 import org.bonitasoft.engine.bpm.process.ModelFinderVisitor;
 import org.bonitasoft.engine.expression.Expression;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlTransient;
 
 /**
  * @author Elias Ricken de Medeiros

--- a/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/flownode/impl/internal/MultiInstanceLoopCharacteristicsImpl.java
+++ b/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/flownode/impl/internal/MultiInstanceLoopCharacteristicsImpl.java
@@ -15,16 +15,16 @@ package org.bonitasoft.engine.bpm.flownode.impl.internal;
 
 import static org.bonitasoft.engine.expression.ExpressionBuilder.getNonNullCopy;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-
 import org.bonitasoft.engine.bpm.flownode.LoopCharacteristics;
 import org.bonitasoft.engine.bpm.flownode.MultiInstanceLoopCharacteristics;
 import org.bonitasoft.engine.bpm.process.ModelFinderVisitor;
 import org.bonitasoft.engine.expression.Expression;
 import org.bonitasoft.engine.expression.impl.ExpressionImpl;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
 
 /**
  * @author Baptiste Mesta

--- a/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/flownode/impl/internal/NameExpressionMap.java
+++ b/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/flownode/impl/internal/NameExpressionMap.java
@@ -16,9 +16,9 @@ package org.bonitasoft.engine.bpm.flownode.impl.internal;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 class NameExpressionMap {

--- a/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/flownode/impl/internal/NameExpressionMapAdapter.java
+++ b/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/flownode/impl/internal/NameExpressionMapAdapter.java
@@ -16,11 +16,11 @@ package org.bonitasoft.engine.bpm.flownode.impl.internal;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.adapters.XmlAdapter;
-
 import org.bonitasoft.engine.expression.Expression;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.adapters.XmlAdapter;
 
 /**
  * @author mazourd

--- a/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/flownode/impl/internal/NameExpressionPair.java
+++ b/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/flownode/impl/internal/NameExpressionPair.java
@@ -13,13 +13,13 @@
  **/
 package org.bonitasoft.engine.bpm.flownode.impl.internal;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-
 import org.bonitasoft.engine.expression.Expression;
 import org.bonitasoft.engine.expression.impl.ExpressionImpl;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 public class NameExpressionPair {

--- a/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/flownode/impl/internal/ReceiveTaskDefinitionImpl.java
+++ b/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/flownode/impl/internal/ReceiveTaskDefinitionImpl.java
@@ -15,16 +15,15 @@ package org.bonitasoft.engine.bpm.flownode.impl.internal;
 
 import static org.bonitasoft.engine.operation.OperationBuilder.getNonNullCopy;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-
 import org.bonitasoft.engine.bpm.flownode.CatchMessageEventTriggerDefinition;
 import org.bonitasoft.engine.bpm.flownode.ReceiveTaskDefinition;
 import org.bonitasoft.engine.bpm.process.ModelFinderVisitor;
 import org.bonitasoft.engine.expression.Expression;
 import org.bonitasoft.engine.operation.Operation;
 
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;

--- a/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/flownode/impl/internal/SendTaskDefinitionImpl.java
+++ b/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/flownode/impl/internal/SendTaskDefinitionImpl.java
@@ -15,15 +15,14 @@ package org.bonitasoft.engine.bpm.flownode.impl.internal;
 
 import static org.bonitasoft.engine.expression.ExpressionBuilder.getNonNullCopy;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-
 import org.bonitasoft.engine.bpm.flownode.SendTaskDefinition;
 import org.bonitasoft.engine.bpm.flownode.ThrowMessageEventTriggerDefinition;
 import org.bonitasoft.engine.bpm.process.ModelFinderVisitor;
 import org.bonitasoft.engine.expression.Expression;
 
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 

--- a/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/flownode/impl/internal/SignalEventTriggerDefinitionImpl.java
+++ b/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/flownode/impl/internal/SignalEventTriggerDefinitionImpl.java
@@ -13,14 +13,13 @@
  **/
 package org.bonitasoft.engine.bpm.flownode.impl.internal;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlTransient;
-
 import org.bonitasoft.engine.bpm.flownode.SignalEventTriggerDefinition;
 import org.bonitasoft.engine.bpm.process.ModelFinderVisitor;
 
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlTransient;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/flownode/impl/internal/StandardLoopCharacteristicsImpl.java
+++ b/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/flownode/impl/internal/StandardLoopCharacteristicsImpl.java
@@ -15,17 +15,16 @@ package org.bonitasoft.engine.bpm.flownode.impl.internal;
 
 import static org.bonitasoft.engine.expression.ExpressionBuilder.getNonNullCopy;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-
 import org.bonitasoft.engine.bpm.flownode.LoopCharacteristics;
 import org.bonitasoft.engine.bpm.flownode.StandardLoopCharacteristics;
 import org.bonitasoft.engine.bpm.process.ModelFinderVisitor;
 import org.bonitasoft.engine.expression.Expression;
 import org.bonitasoft.engine.expression.impl.ExpressionImpl;
 
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;

--- a/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/flownode/impl/internal/TaskDefinitionImpl.java
+++ b/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/flownode/impl/internal/TaskDefinitionImpl.java
@@ -13,9 +13,9 @@
  **/
 package org.bonitasoft.engine.bpm.flownode.impl.internal;
 
-import javax.xml.bind.annotation.XmlTransient;
-
 import org.bonitasoft.engine.bpm.flownode.TaskDefinition;
+
+import jakarta.xml.bind.annotation.XmlTransient;
 
 /**
  * @author Baptiste Mesta

--- a/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/flownode/impl/internal/ThrowEventDefinitionImpl.java
+++ b/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/flownode/impl/internal/ThrowEventDefinitionImpl.java
@@ -17,16 +17,15 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlTransient;
-
 import org.bonitasoft.engine.bpm.flownode.ThrowEventDefinition;
 import org.bonitasoft.engine.bpm.flownode.ThrowMessageEventTriggerDefinition;
 import org.bonitasoft.engine.bpm.flownode.ThrowSignalEventTriggerDefinition;
 import org.bonitasoft.engine.bpm.process.ModelFinderVisitor;
 
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlTransient;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.ToString;

--- a/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/flownode/impl/internal/ThrowMessageEventTriggerDefinitionImpl.java
+++ b/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/flownode/impl/internal/ThrowMessageEventTriggerDefinitionImpl.java
@@ -20,10 +20,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-
 import org.bonitasoft.engine.bpm.data.DataDefinition;
 import org.bonitasoft.engine.bpm.data.impl.DataDefinitionImpl;
 import org.bonitasoft.engine.bpm.flownode.CorrelationDefinition;
@@ -31,6 +27,10 @@ import org.bonitasoft.engine.bpm.flownode.ThrowMessageEventTriggerDefinition;
 import org.bonitasoft.engine.bpm.process.ModelFinderVisitor;
 import org.bonitasoft.engine.expression.Expression;
 import org.bonitasoft.engine.expression.impl.ExpressionImpl;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
 
 /**
  * @author Elias Ricken de Medeiros

--- a/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/flownode/impl/internal/TimerEventTriggerDefinitionImpl.java
+++ b/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/flownode/impl/internal/TimerEventTriggerDefinitionImpl.java
@@ -15,17 +15,16 @@ package org.bonitasoft.engine.bpm.flownode.impl.internal;
 
 import static org.bonitasoft.engine.expression.ExpressionBuilder.getNonNullCopy;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-
 import org.bonitasoft.engine.bpm.flownode.TimerEventTriggerDefinition;
 import org.bonitasoft.engine.bpm.flownode.TimerType;
 import org.bonitasoft.engine.bpm.process.ModelFinderVisitor;
 import org.bonitasoft.engine.expression.Expression;
 import org.bonitasoft.engine.expression.impl.ExpressionImpl;
 
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;

--- a/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/flownode/impl/internal/TransitionDefinitionImpl.java
+++ b/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/flownode/impl/internal/TransitionDefinitionImpl.java
@@ -15,12 +15,6 @@ package org.bonitasoft.engine.bpm.flownode.impl.internal;
 
 import static org.bonitasoft.engine.expression.ExpressionBuilder.getNonNullCopy;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlIDREF;
-
 import org.bonitasoft.engine.bpm.flownode.FlowNodeDefinition;
 import org.bonitasoft.engine.bpm.flownode.TransitionDefinition;
 import org.bonitasoft.engine.bpm.internal.NamedDefinitionElementImpl;
@@ -30,6 +24,11 @@ import org.bonitasoft.engine.expression.impl.ExpressionImpl;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlIDREF;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.ToString;

--- a/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/flownode/impl/internal/UserTaskDefinitionImpl.java
+++ b/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/flownode/impl/internal/UserTaskDefinitionImpl.java
@@ -16,12 +16,6 @@ package org.bonitasoft.engine.bpm.flownode.impl.internal;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlElementWrapper;
-import javax.xml.bind.annotation.XmlType;
-
 import org.bonitasoft.engine.bpm.context.ContextEntry;
 import org.bonitasoft.engine.bpm.context.ContextEntryImpl;
 import org.bonitasoft.engine.bpm.contract.ContractDefinition;
@@ -29,6 +23,11 @@ import org.bonitasoft.engine.bpm.contract.impl.ContractDefinitionImpl;
 import org.bonitasoft.engine.bpm.flownode.UserTaskDefinition;
 import org.bonitasoft.engine.bpm.process.ModelFinderVisitor;
 
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlElementWrapper;
+import jakarta.xml.bind.annotation.XmlType;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/flownode/impl/internal/package-info.java
+++ b/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/flownode/impl/internal/package-info.java
@@ -12,10 +12,10 @@
  * Floor, Boston, MA 02110-1301, USA.
  **/
 @XmlSchema(namespace = NAMESPACE, elementFormDefault = XmlNsForm.UNSET, xmlns = {
-        @javax.xml.bind.annotation.XmlNs(namespaceURI = NAMESPACE, prefix = "tns") })
+        @jakarta.xml.bind.annotation.XmlNs(namespaceURI = NAMESPACE, prefix = "tns") })
 package org.bonitasoft.engine.bpm.flownode.impl.internal;
 
 import static org.bonitasoft.engine.ProcessDefinitionNamespace.NAMESPACE;
 
-import javax.xml.bind.annotation.XmlNsForm;
-import javax.xml.bind.annotation.XmlSchema;
+import jakarta.xml.bind.annotation.XmlNsForm;
+import jakarta.xml.bind.annotation.XmlSchema;

--- a/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/flownode/package-info.java
+++ b/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/flownode/package-info.java
@@ -12,10 +12,10 @@
  * Floor, Boston, MA 02110-1301, USA.
  **/
 @XmlSchema(namespace = NAMESPACE, elementFormDefault = XmlNsForm.UNSET, xmlns = {
-        @javax.xml.bind.annotation.XmlNs(namespaceURI = NAMESPACE, prefix = "tns") })
+        @jakarta.xml.bind.annotation.XmlNs(namespaceURI = NAMESPACE, prefix = "tns") })
 package org.bonitasoft.engine.bpm.flownode;
 
 import static org.bonitasoft.engine.ProcessDefinitionNamespace.NAMESPACE;
 
-import javax.xml.bind.annotation.XmlNsForm;
-import javax.xml.bind.annotation.XmlSchema;
+import jakarta.xml.bind.annotation.XmlNsForm;
+import jakarta.xml.bind.annotation.XmlSchema;

--- a/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/parameter/impl/ParameterDefinitionImpl.java
+++ b/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/parameter/impl/ParameterDefinitionImpl.java
@@ -13,14 +13,13 @@
  **/
 package org.bonitasoft.engine.bpm.parameter.impl;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-
 import org.bonitasoft.engine.bpm.internal.NamedDefinitionElementImpl;
 import org.bonitasoft.engine.bpm.parameter.ParameterDefinition;
 
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;

--- a/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/parameter/impl/package-info.java
+++ b/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/parameter/impl/package-info.java
@@ -12,10 +12,10 @@
  * Floor, Boston, MA 02110-1301, USA.
  **/
 @XmlSchema(namespace = NAMESPACE, elementFormDefault = XmlNsForm.UNSET, xmlns = {
-        @javax.xml.bind.annotation.XmlNs(namespaceURI = NAMESPACE, prefix = "tns") })
+        @jakarta.xml.bind.annotation.XmlNs(namespaceURI = NAMESPACE, prefix = "tns") })
 package org.bonitasoft.engine.bpm.parameter.impl;
 
 import static org.bonitasoft.engine.ProcessDefinitionNamespace.NAMESPACE;
 
-import javax.xml.bind.annotation.XmlNsForm;
-import javax.xml.bind.annotation.XmlSchema;
+import jakarta.xml.bind.annotation.XmlNsForm;
+import jakarta.xml.bind.annotation.XmlSchema;

--- a/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/process/impl/internal/DesignProcessDefinitionImpl.java
+++ b/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/process/impl/internal/DesignProcessDefinitionImpl.java
@@ -24,15 +24,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlElementWrapper;
-import javax.xml.bind.annotation.XmlIDREF;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlSeeAlso;
-
 import org.bonitasoft.engine.bpm.actor.ActorDefinition;
 import org.bonitasoft.engine.bpm.actor.impl.ActorDefinitionImpl;
 import org.bonitasoft.engine.bpm.context.ContextEntry;
@@ -48,6 +39,14 @@ import org.bonitasoft.engine.bpm.process.ModelFinderVisitor;
 import org.bonitasoft.engine.bpm.process.Visitable;
 import org.bonitasoft.engine.expression.Expression;
 
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlElementWrapper;
+import jakarta.xml.bind.annotation.XmlIDREF;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlSeeAlso;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;

--- a/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/process/impl/internal/IndexLabel.java
+++ b/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/process/impl/internal/IndexLabel.java
@@ -17,14 +17,13 @@ import static org.bonitasoft.engine.expression.ExpressionBuilder.getNonNullCopy;
 
 import java.io.Serializable;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-
 import org.bonitasoft.engine.expression.Expression;
 import org.bonitasoft.engine.expression.impl.ExpressionImpl;
 
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;

--- a/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/process/impl/internal/ProcessDefinitionImpl.java
+++ b/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/process/impl/internal/ProcessDefinitionImpl.java
@@ -13,14 +13,13 @@
  **/
 package org.bonitasoft.engine.bpm.process.impl.internal;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-
 import org.bonitasoft.engine.bpm.internal.NamedDefinitionElementImpl;
 import org.bonitasoft.engine.bpm.process.ProcessDefinition;
 
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;

--- a/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/process/impl/internal/SubProcessDefinitionImpl.java
+++ b/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/process/impl/internal/SubProcessDefinitionImpl.java
@@ -13,17 +13,16 @@
  **/
 package org.bonitasoft.engine.bpm.process.impl.internal;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-
 import org.bonitasoft.engine.bpm.flownode.FlowElementContainerDefinition;
 import org.bonitasoft.engine.bpm.flownode.impl.internal.ActivityDefinitionImpl;
 import org.bonitasoft.engine.bpm.flownode.impl.internal.FlowElementContainerDefinitionImpl;
 import org.bonitasoft.engine.bpm.process.ModelFinderVisitor;
 import org.bonitasoft.engine.bpm.process.SubProcessDefinition;
 
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;

--- a/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/process/impl/internal/package-info.java
+++ b/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/process/impl/internal/package-info.java
@@ -12,10 +12,10 @@
  * Floor, Boston, MA 02110-1301, USA.
  **/
 @XmlSchema(namespace = NAMESPACE, elementFormDefault = XmlNsForm.UNSET, xmlns = {
-        @javax.xml.bind.annotation.XmlNs(namespaceURI = NAMESPACE, prefix = "tns") })
+        @jakarta.xml.bind.annotation.XmlNs(namespaceURI = NAMESPACE, prefix = "tns") })
 package org.bonitasoft.engine.bpm.process.impl.internal;
 
 import static org.bonitasoft.engine.ProcessDefinitionNamespace.NAMESPACE;
 
-import javax.xml.bind.annotation.XmlNsForm;
-import javax.xml.bind.annotation.XmlSchema;
+import jakarta.xml.bind.annotation.XmlNsForm;
+import jakarta.xml.bind.annotation.XmlSchema;

--- a/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/userfilter/impl/UserFilterDefinitionImpl.java
+++ b/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/userfilter/impl/UserFilterDefinitionImpl.java
@@ -18,18 +18,17 @@ import static org.bonitasoft.engine.expression.ExpressionBuilder.getNonNullCopy;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
-
 import org.bonitasoft.engine.bpm.flownode.impl.internal.NameExpressionMapAdapter;
 import org.bonitasoft.engine.bpm.internal.NamedDefinitionElementImpl;
 import org.bonitasoft.engine.bpm.process.ModelFinderVisitor;
 import org.bonitasoft.engine.bpm.userfilter.UserFilterDefinition;
 import org.bonitasoft.engine.expression.Expression;
 
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 

--- a/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/userfilter/impl/package-info.java
+++ b/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/userfilter/impl/package-info.java
@@ -12,10 +12,10 @@
  * Floor, Boston, MA 02110-1301, USA.
  **/
 @XmlSchema(namespace = NAMESPACE, elementFormDefault = XmlNsForm.UNSET, xmlns = {
-        @javax.xml.bind.annotation.XmlNs(namespaceURI = NAMESPACE, prefix = "tns") })
+        @jakarta.xml.bind.annotation.XmlNs(namespaceURI = NAMESPACE, prefix = "tns") })
 package org.bonitasoft.engine.bpm.userfilter.impl;
 
 import static org.bonitasoft.engine.ProcessDefinitionNamespace.NAMESPACE;
 
-import javax.xml.bind.annotation.XmlNsForm;
-import javax.xml.bind.annotation.XmlSchema;
+import jakarta.xml.bind.annotation.XmlNsForm;
+import jakarta.xml.bind.annotation.XmlSchema;

--- a/process-definition-model/src/main/java/org/bonitasoft/engine/expression/impl/ExpressionImpl.java
+++ b/process-definition-model/src/main/java/org/bonitasoft/engine/expression/impl/ExpressionImpl.java
@@ -18,17 +18,16 @@ import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlID;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
-
 import org.bonitasoft.engine.bpm.internal.LongToStringAdapter;
 import org.bonitasoft.engine.bpm.process.ModelFinderVisitor;
 import org.bonitasoft.engine.expression.Expression;
 
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlID;
+import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/process-definition-model/src/main/java/org/bonitasoft/engine/expression/impl/package-info.java
+++ b/process-definition-model/src/main/java/org/bonitasoft/engine/expression/impl/package-info.java
@@ -12,10 +12,10 @@
  * Floor, Boston, MA 02110-1301, USA.
  **/
 @XmlSchema(namespace = NAMESPACE, elementFormDefault = XmlNsForm.UNSET, xmlns = {
-        @javax.xml.bind.annotation.XmlNs(namespaceURI = NAMESPACE, prefix = "tns") })
+        @jakarta.xml.bind.annotation.XmlNs(namespaceURI = NAMESPACE, prefix = "tns") })
 package org.bonitasoft.engine.expression.impl;
 
 import static org.bonitasoft.engine.ProcessDefinitionNamespace.NAMESPACE;
 
-import javax.xml.bind.annotation.XmlNsForm;
-import javax.xml.bind.annotation.XmlSchema;
+import jakarta.xml.bind.annotation.XmlNsForm;
+import jakarta.xml.bind.annotation.XmlSchema;

--- a/process-definition-model/src/main/java/org/bonitasoft/engine/operation/impl/LeftOperandImpl.java
+++ b/process-definition-model/src/main/java/org/bonitasoft/engine/operation/impl/LeftOperandImpl.java
@@ -13,11 +13,11 @@
  **/
 package org.bonitasoft.engine.operation.impl;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-
 import org.bonitasoft.engine.operation.LeftOperand;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
 
 /**
  * @author Zhang Bole

--- a/process-definition-model/src/main/java/org/bonitasoft/engine/operation/impl/OperationImpl.java
+++ b/process-definition-model/src/main/java/org/bonitasoft/engine/operation/impl/OperationImpl.java
@@ -13,11 +13,6 @@
  **/
 package org.bonitasoft.engine.operation.impl;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-
 import org.bonitasoft.engine.bpm.process.ModelFinderVisitor;
 import org.bonitasoft.engine.expression.Expression;
 import org.bonitasoft.engine.expression.ExpressionBuilder;
@@ -25,6 +20,11 @@ import org.bonitasoft.engine.expression.impl.ExpressionImpl;
 import org.bonitasoft.engine.operation.LeftOperand;
 import org.bonitasoft.engine.operation.Operation;
 import org.bonitasoft.engine.operation.OperatorType;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
 
 /**
  * @author Zhang Bole

--- a/process-definition-model/src/main/java/org/bonitasoft/engine/operation/impl/package-info.java
+++ b/process-definition-model/src/main/java/org/bonitasoft/engine/operation/impl/package-info.java
@@ -12,10 +12,10 @@
  * Floor, Boston, MA 02110-1301, USA.
  **/
 @XmlSchema(namespace = NAMESPACE, elementFormDefault = XmlNsForm.UNSET, xmlns = {
-        @javax.xml.bind.annotation.XmlNs(namespaceURI = NAMESPACE, prefix = "tns") })
+        @jakarta.xml.bind.annotation.XmlNs(namespaceURI = NAMESPACE, prefix = "tns") })
 package org.bonitasoft.engine.operation.impl;
 
 import static org.bonitasoft.engine.ProcessDefinitionNamespace.NAMESPACE;
 
-import javax.xml.bind.annotation.XmlNsForm;
-import javax.xml.bind.annotation.XmlSchema;
+import jakarta.xml.bind.annotation.XmlNsForm;
+import jakarta.xml.bind.annotation.XmlSchema;

--- a/process-definition-model/src/main/java/org/bonitasoft/engine/operation/package-info.java
+++ b/process-definition-model/src/main/java/org/bonitasoft/engine/operation/package-info.java
@@ -12,10 +12,10 @@
  * Floor, Boston, MA 02110-1301, USA.
  **/
 @XmlSchema(namespace = NAMESPACE, elementFormDefault = XmlNsForm.UNSET, xmlns = {
-        @javax.xml.bind.annotation.XmlNs(namespaceURI = NAMESPACE, prefix = "tns") })
+        @jakarta.xml.bind.annotation.XmlNs(namespaceURI = NAMESPACE, prefix = "tns") })
 package org.bonitasoft.engine.operation;
 
 import static org.bonitasoft.engine.ProcessDefinitionNamespace.NAMESPACE;
 
-import javax.xml.bind.annotation.XmlNsForm;
-import javax.xml.bind.annotation.XmlSchema;
+import jakarta.xml.bind.annotation.XmlNsForm;
+import jakarta.xml.bind.annotation.XmlSchema;

--- a/profile-model/pom.xml
+++ b/profile-model/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.bonitasoft.engine</groupId>
     <artifactId>bonita-artifacts-model-parent</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>bonita-profile-model</artifactId>
   <name>Bonita Profile Model</name>
@@ -26,24 +26,12 @@
       <artifactId>bonita-common-artifacts-model</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.xml.bind</groupId>
-      <artifactId>jaxb-api</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>javax.activation</groupId>
-          <artifactId>javax.activation-api</artifactId>
-        </exclusion>
-      </exclusions>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jaxb</groupId>
       <artifactId>jaxb-runtime</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>javax.activation</groupId>
-          <artifactId>javax.activation-api</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.sun.activation</groupId>

--- a/profile-model/src/main/java/org/bonitasoft/engine/profile/ProfilesParser.java
+++ b/profile-model/src/main/java/org/bonitasoft/engine/profile/ProfilesParser.java
@@ -16,12 +16,12 @@ package org.bonitasoft.engine.profile;
 import java.net.URL;
 import java.util.Optional;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-
 import org.bonitasoft.engine.profile.xml.ProfilesNode;
 import org.bonitasoft.engine.xml.parser.AbstractParser;
 import org.glassfish.hk2.osgiresourcelocator.ResourceFinder;
+
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
 
 /**
  * @author Baptiste Mesta

--- a/profile-model/src/main/java/org/bonitasoft/engine/profile/xml/MembershipNode.java
+++ b/profile-model/src/main/java/org/bonitasoft/engine/profile/xml/MembershipNode.java
@@ -16,10 +16,10 @@ package org.bonitasoft.engine.profile.xml;
 import java.util.Objects;
 import java.util.StringJoiner;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlType;
 
 /**
  * @author Baptiste Mesta

--- a/profile-model/src/main/java/org/bonitasoft/engine/profile/xml/ProfileMappingNode.java
+++ b/profile-model/src/main/java/org/bonitasoft/engine/profile/xml/ProfileMappingNode.java
@@ -19,11 +19,11 @@ import java.util.List;
 import java.util.Objects;
 import java.util.StringJoiner;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlElementWrapper;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlElementWrapper;
+import jakarta.xml.bind.annotation.XmlType;
 
 /**
  * @author Zhao Na

--- a/profile-model/src/main/java/org/bonitasoft/engine/profile/xml/ProfileNode.java
+++ b/profile-model/src/main/java/org/bonitasoft/engine/profile/xml/ProfileNode.java
@@ -16,11 +16,11 @@ package org.bonitasoft.engine.profile.xml;
 import java.util.Objects;
 import java.util.StringJoiner;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlType;
 
 /**
  * @author Zhao Na

--- a/profile-model/src/main/java/org/bonitasoft/engine/profile/xml/ProfilesNode.java
+++ b/profile-model/src/main/java/org/bonitasoft/engine/profile/xml/ProfilesNode.java
@@ -16,10 +16,10 @@ package org.bonitasoft.engine.profile.xml;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 /**
  * @author Baptiste Mesta

--- a/profile-model/src/main/java/org/bonitasoft/engine/profile/xml/package-info.java
+++ b/profile-model/src/main/java/org/bonitasoft/engine/profile/xml/package-info.java
@@ -15,5 +15,5 @@
         @XmlNs(prefix = "profiles", namespaceURI = "http://documentation.bonitasoft.com/profile-xml-schema/1.0") })
 package org.bonitasoft.engine.profile.xml;
 
-import javax.xml.bind.annotation.XmlNs;
-import javax.xml.bind.annotation.XmlSchema;
+import jakarta.xml.bind.annotation.XmlNs;
+import jakarta.xml.bind.annotation.XmlSchema;


### PR DESCRIPTION
## Summary

This PR completes the migration from Java EE (javax.xml.bind) to Jakarta EE (jakarta.xml.bind) across all 10 modules in the bonita-artifacts-model project.

**Breaking Change:** This is a major version upgrade (1.3.0 → 2.0.0-SNAPSHOT) due to the namespace change from `javax.*` to `jakarta.*`.

## What Changed

### Core Migration
- ✅ **All Java imports** updated from `javax.xml.bind.*` to `jakarta.xml.bind.*` (154 files)
- ✅ **All package-info.java files** updated with Jakarta annotations
- ✅ **JAXB Maven plugin** upgraded from 2.5.0 to 3.1.0 (org.codehaus.mojo)
- ✅ **Dependencies** migrated to Jakarta equivalents
- ✅ **Version bumped** to 2.0.0-SNAPSHOT (semantic versioning for breaking change)

### Dependencies Updated

| Dependency | Before (javax) | After (jakarta) |
|------------|----------------|-----------------|
| **JAXB API** | javax.xml.bind:jaxb-api:2.3.1 | jakarta.xml.bind:jakarta.xml.bind-api:3.0.1 |
| **JAXB Runtime** | org.glassfish.jaxb:jaxb-runtime:2.3.1 | org.glassfish.jaxb:jaxb-runtime:3.0.2 |
| **Jakarta Activation** | com.sun.activation:jakarta.activation:1.2.2 | com.sun.activation:jakarta.activation:2.0.1 |
| **istack-commons** | com.sun.istack:istack-commons-runtime:3.0.7 | com.sun.istack:istack-commons-runtime:4.0.1 |

### POM Simplifications
- ✅ **Removed all javax.activation exclusions** (no longer needed - Jakarta JAXB 3.x has no javax dependencies)
- ✅ **Cleaner dependency tree** - removed 2 legacy artifacts (stax-ex, FastInfoset)

## Modules Migrated (10/10)

- common-artifacts-model
- process-definition-model  
- business-object-model
- bdm-access-control-model
- profile-model
- organization-model
- application-model
- connector-model
- form-mapping-model
- business-archive

## Testing

✅ **All 305 tests passing** (0 failures, 0 errors, 0 skipped)
✅ **XSD generation working correctly** in all modules
✅ **Full build successful** with parallel execution (`-T 4`)
✅ **Spotless formatting** applied across all modules

## XSD Schema Verification

**Critical verification:** All generated XSD schemas are **byte-identical** before and after migration.

### Verification Process
1. Built project at commit `3315bcb` (before migration, javax)
2. Collected all 9 generated XSD files
3. Built project at commit `496eee2` (after migration, jakarta)
4. Collected all 9 generated XSD files
5. Performed binary diff comparison: `diff -r xsd-before xsd-after`
6. Verified SHA256 checksums

### Results

| Schema File | Size | Status |
|-------------|------|--------|
| application.xsd | 3,325 bytes | ✅ IDENTICAL |
| bdm-access-control.xsd | 2,385 bytes | ✅ IDENTICAL |
| bom.xsd | 6,374 bytes | ✅ IDENTICAL |
| connector-definition-descriptor.xsd | 5,196 bytes | ✅ IDENTICAL |
| connectors-impl.xsd | 1,314 bytes | ✅ IDENTICAL |
| form-mapping.xsd | 1,640 bytes | ✅ IDENTICAL |
| organization.xsd | 6,684 bytes | ✅ IDENTICAL |
| ProcessDefinition.xsd | 48,667 bytes | ✅ IDENTICAL |
| profiles.xsd | 2,333 bytes | ✅ IDENTICAL |

**Conclusion:** The migration produces identical XSD output, ensuring zero impact on XML consumers and backward compatibility.

## JAXB Maven Plugin Decision

The PR uses `org.codehaus.mojo:jaxb2-maven-plugin:3.1.0` (upgraded from 2.5.0).

**Why this plugin:**
- ✅ Version 3.0.0+ fully supports Jakarta EE (JAXB 3.0)
- ✅ Uses `jakarta.xml.bind-api:3.0.0` internally
- ✅ Generates byte-identical XSD schemas (verified above)
- ✅ Drop-in replacement requiring no configuration changes
- ✅ All 305 tests passing
- ✅ Maintained by MojoHaus community

**Alternative considered:**
- `org.jvnet.jaxb:jaxb-maven-plugin:4.0.8` - Offers more advanced features but not required for our use case

**References:**
- [MojoHaus JAXB2 Plugin Dependencies](https://www.mojohaus.org/jaxb2-maven-plugin/Documentation/v3.1.0/dependencies.html)
- [Jakarta Support Discussion](https://github.com/mojohaus/jaxb2-maven-plugin/issues/138)
- [Release Notes](https://github.com/mojohaus/jaxb2-maven-plugin/releases) - Version 3.0.0 introduced JAXB 3 support

## Dependency Tree Comparison

### Before Migration (javax)
```
javax.xml.bind:jaxb-api:2.3.1
org.glassfish.jaxb:jaxb-runtime:2.3.1
  ├── org.jvnet.staxex:stax-ex:1.8
  ├── com.sun.xml.fastinfoset:FastInfoset:1.2.15
  └── com.sun.istack:istack-commons-runtime:3.0.7
com.sun.activation:jakarta.activation:1.2.2
```

### After Migration (jakarta)
```
jakarta.xml.bind:jakarta.xml.bind-api:3.0.1
org.glassfish.jaxb:jaxb-runtime:3.0.2
  └── org.glassfish.jaxb:jaxb-core:3.0.2
      └── com.sun.istack:istack-commons-runtime:4.0.1
com.sun.activation:jakarta.activation:2.0.1
```

## Benefits

1. **Jakarta EE 9+ Compliance** - Aligned with modern Jakarta EE specifications
2. **Future-Proof** - Ready for Java 17+ and beyond
3. **Cleaner Dependencies** - Removed legacy artifacts, simplified tree
4. **Better Maintained** - Active Jakarta EE community support
5. **No Code Complexity Added** - Net reduction of 146 lines
6. **Backward Compatible** - Identical XSD output ensures zero impact on consumers

## Code Changes

- **Files changed:** 154
- **Lines added:** +598
- **Lines removed:** -744
- **Net change:** -146 lines (simpler code)

## Migration Notes

### Critical Fix: Jakarta Activation 2.0.1
The upgrade from `jakarta.activation:1.2.2` to `2.0.1` was essential. Version 1.2.2 still contains javax packages internally, while 2.0.1 is the first version with proper Jakarta EE 9+ support.

### Removed Superfluous Exclusions
All `javax.activation` exclusions were removed from module POMs because Jakarta JAXB 3.x dependencies natively depend on `jakarta.activation` with no transitive javax dependencies.

### XSD Schema Compatibility
XSD schemas remain byte-identical, ensuring:
- No breaking changes for downstream XML consumers
- Existing XML documents remain valid
- No schema migration needed for clients

## Checklist

- [x] All Java imports updated to jakarta namespace
- [x] All package-info.java files updated
- [x] All module POMs updated with Jakarta dependencies
- [x] JAXB Maven plugin upgraded to 3.1.0
- [x] Parent version bumped to 2.0.0-SNAPSHOT
- [x] All tests passing (305/305)
- [x] XSD generation verified in all modules
- [x] XSD schemas verified byte-identical (before/after)
- [x] Code formatting applied (Spotless)
- [x] Dependency tree verified (no javax artifacts)
- [x] Build successful with parallel execution
- [x] Migration plan documentation updated

## Test Plan

To verify this PR:
```bash
./mvnw clean verify -T 4
```

Expected result:
- ✅ All 305 tests pass
- ✅ XSD files generated correctly in all modules  
- ✅ No javax.xml.bind or javax.activation artifacts in dependency tree

To verify XSD compatibility:
```bash
# Compare generated schemas before/after
find . -name "*.xsd" -path "*/target/classes/*"
```
