### PR TITLE
ci(release): refactor release workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,26 +1,44 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
 updates:
-
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
+    # Set the directory to "/" to check for workflow files in .github/workflows
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "sunday"
+      time: "05:00"
+    labels:
+      - dependencies
+      - github_actions
     commit-message:
       prefix: "chore"
       include: "scope"
 
   # Maintain dependencies for maven
-  - package-ecosystem: "maven" 
-    directory: "/" 
-    target-branch: develop
+  - package-ecosystem: "maven"
+    directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "sunday"
+      time: "06:00"
+    labels:
+      - dependencies
     commit-message:
       prefix: "chore"
       include: "scope"
+    ignore:
+      - dependency-name: "*bonitasoft*"
+    groups:
+      maven-plugins:
+        patterns:
+          - "*maven.plugins*"
+      test:
+        patterns:
+          - "*assertj*"
+          - "*junit*"
+          - "*test*"
+          - "*mockito*"
+      jaxb:
+        patterns:
+          - "*jaxb*"

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -6,14 +6,19 @@ on:
       - develop
       - release/*
       - support/*
+    paths-ignore:
+      - ".github/**"
+      - "!.github/workflows/build-pr.yml"
+      - "**/*.md"
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+
       - name: Setup Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 17

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,7 @@
 name: Build
 
+run-name: Build ${{ github.ref_name }}
+
 on:
   push:
     branches:
@@ -7,22 +9,21 @@ on:
       - release/*
       - support/*
     paths-ignore:
-      - "**/README.md"
-      - "CONTRIBUTING.md"
       - ".github/**"
       - "!.github/workflows/build.yml"
+      - "**/*.md"
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 17

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,12 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "develop", "master", "support/*" ]
+    branches: ["develop", "master", "support/*"]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "develop" ]
-  schedule:
-    - cron: '34 21 * * 4'
+    branches: ["develop"]
 
 jobs:
   analyze:
@@ -38,50 +36,51 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'java' ]
+        language: ["java"]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby', 'swift' ]
         # Use only 'java' to analyze code written in Java, Kotlin or both
         # Use only 'javascript' to analyze code written in JavaScript, TypeScript or both
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v6
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
-      with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
 
-        # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
+          # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+          # queries: security-extended,security-and-quality
 
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        distribution: 'adopt'
-        java-version: 17
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: "temurin"
+          java-version: 17
+          cache: maven
 
-    # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
+      # If this step fails, then you should remove it and run the build manually (see below)
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v4
 
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
 
-    #   If the Autobuild fails above, remove it and uncomment the following three lines.
-    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
+      #   If the Autobuild fails above, remove it and uncomment the following three lines.
+      #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
 
-    # - run: |
-    #     echo "Run, Build Application using script"
-    #     ./location_of_script_within_repo/buildscript.sh
+      # - run: |
+      #     echo "Run, Build Application using script"
+      #     ./location_of_script_within_repo/buildscript.sh
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
-      with:
-        category: "/language:${{matrix.language}}"
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{matrix.language}}"

--- a/.github/workflows/commit-message-check-format.yml
+++ b/.github/workflows/commit-message-check-format.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   pr-title:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       pull-requests: write # post comments when the PR title doesn't match the "Conventional Commits" rules
     steps:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: TimonVS/pr-labeler-action@v4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,7 @@
 name: Publish
 
+run-name: Publish ${{ github.event.inputs.tag }}
+
 on:
   workflow_dispatch:
     inputs:
@@ -12,15 +14,15 @@ on:
 jobs:
   build:
     name: Publication pipeline
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.tag }}
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 17

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,44 +1,56 @@
 name: Release
 
+run-name: Release ${{ github.event.inputs.version || '' }}
+
 on:
   workflow_dispatch:
     inputs:
       version:
-        description: Version to release (leave empty to use pom version)
+        description: 'Version to release (leave empty to use pom version)'
         type: string
         default: ''
-        required: false
-      nextVersion:
-        description: 'Next development version (leave empty to use default version incrementation policy)'
+      nextDevelopmentVersion:
+        description: 'Next development version (leave empty to use versionDigitToIncrement policy)'
         type: string
-        required: false
         default: ''
-      skipMergeReleaseInMaster:
-        description: 'Whether release branch merge should be skip into master (major/minor version only should be merged)'
-        type: boolean
-        required: false
-        default: false
+      versionDigitToIncrement:
+        description: 'Version digit to increment in the next development version: 0=major (X.0.0), 1=minor (X.Y.0), 2=patch (X.Y.Z)'
+        type: choice
+        default: '2'
+        options:
+          - '0'
+          - '1'
+          - '2'
 
 jobs:
   build:
     name: Release pipeline
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          fetch-depth: '0'
-        
+          fetch-depth: 0
+
       - name: Setup Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
-          distribution: 'temurin'
+          distribution: temurin
           java-version: 17
-       
-      - name: Configure Git user
-        run: |
-          git config user.email "actions@github.com"
-          git config user.name "GitHub Actions"
-      
-      - name: Create Release 
-        run: ./mvnw -ntp --batch-mode -Dstyle.color=always gitflow:release -DgitFlowConfig.developmentBranch=${{ github.ref_name }} -DdevelopmentVersion=${{ github.event.inputs.nextVersion }} -DreleaseVersion=${{ github.event.inputs.version }} -DskipReleaseMergeProdBranch=${{ github.event.inputs.skipMergeReleaseInMaster }} -Dverbose
+          cache: maven
+
+      - uses: bonitasoft/maven-settings-action@v1
+        with:
+          keeper-secret-config: ${{ secrets.KSM_CONFIG }}
+
+      - uses: bonitasoft/git-setup-action@v1
+        with:
+          keeper-secret-config: ${{ secrets.KSM_CONFIG }}
+
+      - name: Create Release
+        run: >
+          ./mvnw -ntp --batch-mode gitflow:release
+          -DgitFlowConfig.developmentBranch=${{ github.ref_name }}
+          -DreleaseVersion=${{ github.event.inputs.version }}
+          -DdevelopmentVersion=${{ github.event.inputs.nextDevelopmentVersion }}
+          -DversionDigitToIncrement=${{ github.event.inputs.versionDigitToIncrement }}

--- a/pom.xml
+++ b/pom.xml
@@ -297,8 +297,12 @@
           <version>${gitflow-maven-plugin.version}</version>
           <configuration>
             <versionsMavenPluginVersion>${versions-maven-plugin.version}</versionsMavenPluginVersion>
-            <!-- 0: increment major digit on develop, 1: increment minor digit on develop, 2: increment patch digit on develop -->
-            <versionDigitToIncrement>1</versionDigitToIncrement>
+            <gitFlowConfig>
+              <productionBranch>develop</productionBranch>
+              <developmentBranch>develop</developmentBranch>
+              <supportBranchPrefix>support/</supportBranchPrefix>
+            </gitFlowConfig>
+            <skipReleaseMergeProdBranch>true</skipReleaseMergeProdBranch>
             <commitMessagePrefix xml:space="preserve">chore(release): </commitMessagePrefix>
           </configuration>
         </plugin>


### PR DESCRIPTION
- Add versionDigitToIncrement workflow input (0=major, 1=minor, 2=patch) to allow users to control version bumping strategy per release
- Remove hardcoded versionDigitToIncrement from pom.xml to allow dynamic configuration via workflow
- Configure gitflow-maven-plugin with proper branch settings:
  * Set productionBranch and developmentBranch to 'develop'
  * Document supportBranchPrefix as 'support/'
  * Enable skipReleaseMergeProdBranch (master branch removed)
- Rename workflow input 'nextVersion' to 'nextDevelopmentVersion' for clarity
- Remove 'skipMergeReleaseInMaster' workflow input (now configured in pom.xml)
- Improve release command readability with multiline format
- Add maven cache to workflow for faster builds
- Add workflow run-name for better visibility in Actions UI
- Upgrade github actions and runners