### PR TITLE
chore: migrate to Java 17 and cleanup dependencies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,8 +132,8 @@ Example: `feat(business-object-model): add support for multiple queries`
 
 ## Java Version
 
-- Requires **Java 11** for compilation
-- Maven compiler is configured to target Java 11 (`maven.compiler.release=11`)
+- Requires **Java 17** for compilation
+- Maven compiler is configured to target Java 17 (`maven.compiler.release=17`)
 - Uses Maven wrapper (`./mvnw`) - Maven 3.8.6+
 
 ## Regenerating AssertJ Classes

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This repository contains the different modules that define the Bonita Runtime mo
 
 ## Prerequisites
 
-* [Java 11][java] for compilation
+* [Java 17][java] for compilation
 
 ## How to build
 
@@ -146,5 +146,5 @@ develop.
 * [Documentation][documentation]
 
 
-[java]: https://adoptium.net/temurin/releases/?version=11
+[java]: https://adoptium.net/temurin/releases/?version=17
 [documentation]: https://documentation.bonitasoft.com

--- a/application-model/pom.xml
+++ b/application-model/pom.xml
@@ -39,10 +39,6 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
-      <groupId>org.glassfish.hk2</groupId>
-      <artifactId>osgi-resource-locator</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>

--- a/artifacts-model-dependencies/pom.xml
+++ b/artifacts-model-dependencies/pom.xml
@@ -10,6 +10,12 @@
   <packaging>pom</packaging>
   <name>Bonita Artifacts Model Dependencies</name>
   <description>This module is the Bill of Material of the Artifacts Model modules</description>
+  <properties>
+    <jakarta.activation.version>2.0.1</jakarta.activation.version>
+    <jakarta.xml.bind-api.version>3.0.1</jakarta.xml.bind-api.version>
+    <jaxb-runtime.version>3.0.2</jaxb-runtime.version>
+    <osgi-resource-locator.version>3.0.0</osgi-resource-locator.version>
+  </properties>
   <dependencyManagement>
     <dependencies>
       <dependency>
@@ -65,22 +71,22 @@
       <dependency>
         <groupId>com.sun.activation</groupId>
         <artifactId>jakarta.activation</artifactId>
-        <version>2.0.1</version>
+        <version>${jakarta.activation.version}</version>
       </dependency>
       <dependency>
         <groupId>jakarta.xml.bind</groupId>
         <artifactId>jakarta.xml.bind-api</artifactId>
-        <version>3.0.1</version>
+        <version>${jakarta.xml.bind-api.version}</version>
       </dependency>
       <dependency>
         <groupId>org.glassfish.jaxb</groupId>
         <artifactId>jaxb-runtime</artifactId>
-        <version>3.0.2</version>
+        <version>${jaxb-runtime.version}</version>
       </dependency>
       <dependency>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>osgi-resource-locator</artifactId>
-        <version>3.0.0</version>
+        <version>${osgi-resource-locator.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -44,39 +44,46 @@
     <url>https://github.com/bonitasoft/bonita-artifacts-model</url>
   </scm>
   <properties>
+    <!-- Java version -->
+    <maven.compiler.release>17</maven.compiler.release>
     <!-- Properties encoding used by the maven compiler -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <java.version>11</java.version>
-    <maven.compiler.release>${java.version}</maven.compiler.release>
+    <!-- Dependency versions -->
+    <assertj-core.version>3.27.7</assertj-core.version>
+    <build-helper-maven-plugin.version>3.6.1</build-helper-maven-plugin.version>
+    <central-maven-plugin.version>0.10.0</central-maven-plugin.version>
+    <flatten-maven-plugin.version>1.6.0</flatten-maven-plugin.version>
+    <git-commit-id-plugin.version>4.9.10</git-commit-id-plugin.version>
+    <gitflow-maven-plugin.version>1.21.0</gitflow-maven-plugin.version>
+    <groovy-maven-plugin.version>2.1.1</groovy-maven-plugin.version>
+    <groovy.version>3.0.25</groovy.version>
+    <jackson-bom.version>2.21.0</jackson-bom.version>
+    <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
+    <jaxb2-maven-plugin.version>4.1.0</jaxb2-maven-plugin.version>
     <junit-bom.version>6.0.2</junit-bom.version>
-    <mockito-junit-jupiter.version>5.21.0</mockito-junit-jupiter.version>
+    <junit.version>4.13.2</junit.version>
+    <lombok.version>1.18.42</lombok.version>
     <maven-clean-plugin.version>3.5.0</maven-clean-plugin.version>
     <maven-compiler-plugin.version>3.14.1</maven-compiler-plugin.version>
     <maven-dependency-plugin.version>3.9.0</maven-dependency-plugin.version>
+    <maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
     <maven-enforcer-plugin.version>3.6.2</maven-enforcer-plugin.version>
     <maven-failsafe-plugin.version>3.5.4</maven-failsafe-plugin.version>
+    <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
     <maven-help-plugin.version>3.2.0</maven-help-plugin.version>
     <maven-install-plugin.version>3.1.4</maven-install-plugin.version>
     <maven-jar-plugin.version>3.5.0</maven-jar-plugin.version>
     <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
-    <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
     <maven-resources-plugin.version>3.4.0</maven-resources-plugin.version>
+    <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
     <maven-surefire-plugin.version>3.5.4</maven-surefire-plugin.version>
-    <git-commit-id-plugin.version>4.9.10</git-commit-id-plugin.version>
-    <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
-    <central-maven-plugin.version>0.10.0</central-maven-plugin.version>
-    <maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
-    <gitflow-maven-plugin.version>1.21.0</gitflow-maven-plugin.version>
+    <mockito-junit-jupiter.version>5.21.0</mockito-junit-jupiter.version>
+    <mockito-core.version>5.21.0</mockito-core.version>
+    <slf4j-api.version>2.0.0</slf4j-api.version>
     <sonar-maven-plugin.version>5.0.0.4389</sonar-maven-plugin.version>
-    <versions-maven-plugin.version>2.18.0</versions-maven-plugin.version>
-    <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
-    <flatten-maven-plugin.version>1.6.0</flatten-maven-plugin.version>
-    <build-helper-maven-plugin.version>3.6.1</build-helper-maven-plugin.version>
     <spotless-maven-plugin.version>2.46.1</spotless-maven-plugin.version>
-    <jaxb2-maven-plugin.version>4.1.0</jaxb2-maven-plugin.version>
-    <groovy-maven-plugin.version>2.1.1</groovy-maven-plugin.version>
-    <groovy.version>3.0.25</groovy.version>
+    <versions-maven-plugin.version>2.18.0</versions-maven-plugin.version>
     <!-- Spotless resources location -->
     <eclipse.formatter.file>${maven.multiModuleProjectDirectory}/formatter.xml</eclipse.formatter.file>
     <eclipse.importorder.file>${maven.multiModuleProjectDirectory}/eclipse.importorder</eclipse.importorder.file>
@@ -87,41 +94,41 @@
     <sonar.organization>bonitasoft</sonar.organization>
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     <sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/../coverage-report/target/site/jacoco-aggregate/jacoco.xml,
-			${project.basedir}/coverage-report/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
+      ${project.basedir}/coverage-report/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
   </properties>
   <dependencyManagement>
     <dependencies>
       <dependency>
         <groupId>com.fasterxml.jackson</groupId>
         <artifactId>jackson-bom</artifactId>
-        <version>2.21.0</version>
+        <version>${jackson-bom.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>2.0.0</version>
+        <version>${slf4j-api.version}</version>
       </dependency>
       <dependency>
         <groupId>org.projectlombok</groupId>
         <artifactId>lombok</artifactId>
-        <version>1.18.42</version>
+        <version>${lombok.version}</version>
       </dependency>
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>4.13.2</version>
+        <version>${junit.version}</version>
       </dependency>
       <dependency>
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
-        <version>3.27.7</version>
+        <version>${assertj-core.version}</version>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
-        <version>5.21.0</version>
+        <version>${mockito-core.version}</version>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,6 @@
     <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
     <maven-surefire-plugin.version>3.5.4</maven-surefire-plugin.version>
     <mockito-junit-jupiter.version>5.21.0</mockito-junit-jupiter.version>
-    <mockito-core.version>5.21.0</mockito-core.version>
     <slf4j-api.version>2.0.0</slf4j-api.version>
     <sonar-maven-plugin.version>5.0.0.4389</sonar-maven-plugin.version>
     <spotless-maven-plugin.version>2.46.1</spotless-maven-plugin.version>
@@ -125,11 +124,6 @@
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
         <version>${assertj-core.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.mockito</groupId>
-        <artifactId>mockito-core</artifactId>
-        <version>${mockito-core.version}</version>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,6 @@
     <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
     <jaxb2-maven-plugin.version>4.1.0</jaxb2-maven-plugin.version>
     <junit-bom.version>6.0.2</junit-bom.version>
-    <junit.version>4.13.2</junit.version>
     <lombok.version>1.18.42</lombok.version>
     <maven-clean-plugin.version>3.5.0</maven-clean-plugin.version>
     <maven-compiler-plugin.version>3.14.1</maven-compiler-plugin.version>
@@ -106,6 +105,13 @@
         <scope>import</scope>
       </dependency>
       <dependency>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
+        <version>${junit-bom.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
         <version>${slf4j-api.version}</version>
@@ -114,11 +120,6 @@
         <groupId>org.projectlombok</groupId>
         <artifactId>lombok</artifactId>
         <version>${lombok.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <version>${junit.version}</version>
       </dependency>
       <dependency>
         <groupId>org.assertj</groupId>
@@ -134,13 +135,6 @@
         <groupId>org.mockito</groupId>
         <artifactId>mockito-junit-jupiter</artifactId>
         <version>${mockito-junit-jupiter.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.junit</groupId>
-        <artifactId>junit-bom</artifactId>
-        <version>${junit-bom.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
## Summary

- Migrate from Java 11 to Java 17
- Remove unused JUnit 4 dependency (codebase uses JUnit 5 only)
- Remove unused `mockito-core` from parent pom (transitive via `mockito-junit-jupiter`)
- Remove unused `osgi-resource-locator` from application-model
- Extract hardcoded versions in BOM to properties

## Test plan

- [x] Build passes (`./mvnw clean verify`)
- [x] All tests pass
- [x] CI workflows already configured for Java 17

🤖 Generated with [Claude Code](https://claude.ai/code)