### PR TITLE
chore(deps): Downgrade maven-jar-plugin to 3.4.2 and pin dependabot ignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,9 @@ updates:
       include: "scope"
     ignore:
       - dependency-name: "*bonitasoft*"
+      # Skip maven-jar-plugin 3.5.0+ due to Guice incompatibility (BPA-427)
+      - dependency-name: "*maven-jar-plugin*"
+        versions: ["[3.5.0,)"]
     groups:
       maven-plugins:
         patterns:

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
     <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
     <maven-help-plugin.version>3.2.0</maven-help-plugin.version>
     <maven-install-plugin.version>3.1.4</maven-install-plugin.version>
-    <maven-jar-plugin.version>3.5.0</maven-jar-plugin.version>
+    <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
     <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
     <maven-resources-plugin.version>3.5.0</maven-resources-plugin.version>
     <maven-source-plugin.version>3.4.0</maven-source-plugin.version>


### PR DESCRIPTION
## Summary

`maven-jar-plugin` 3.5.0+ has a Guice incompatibility (BPA-427). This PR mirrors the fixes already applied in [bonita-project#290](https://github.com/bonitasoft/bonita-project/pull/290) and [bonita-project-maven-plugin#500](https://github.com/bonitasoft/bonita-project-maven-plugin/pull/500):

- Downgrade `maven-jar-plugin` from `3.5.0` to `3.4.2` in `pom.xml`
- Add a dependabot ignore entry using **Maven range syntax** `[3.5.0,)` so any 3.5.x or later release is skipped until the upstream incompatibility is resolved

> Note: dependabot's `versions:` field for the Maven ecosystem requires bracket-notation ranges, **not** npm-style wildcards (`"3.5.x"` silently no-ops). See the [GitHub Dependabot options reference](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference).

Relates to [BPA-427](https://bonitasoft.atlassian.net/browse/BPA-427)
Covers [BPA-500](https://bonitasoft.atlassian.net/browse/BPA-500)

## Test plan

- [ ] CI green on `./mvnw clean verify`
- [ ] Resolved `maven-jar-plugin` version is `3.4.2` in the build
- [ ] No new dependabot PR proposing `maven-jar-plugin` 3.5.x or later on the next scheduled run

[BPA-427]: https://bonitasoft.atlassian.net/browse/BPA-427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[BPA-500]: https://bonitasoft.atlassian.net/browse/BPA-500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ