### PR TITLE
chore(rebranding): update bonitasoft.com domain references to ofelia.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,4 +147,4 @@ develop.
 
 
 [java]: https://adoptium.net/temurin/releases/?version=17
-[documentation]: https://documentation.bonitasoft.com
+[documentation]: https://documentation.ofelia.com

--- a/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/process/DesignProcessDefinition.java
+++ b/process-definition-model/src/main/java/org/bonitasoft/engine/bpm/process/DesignProcessDefinition.java
@@ -104,7 +104,7 @@ public interface DesignProcessDefinition extends ProcessDefinition {
      * Retrieves the label for the ProcessDefinition given search key, also known as string index.
      * <p>
      * You can define up to five search keys for a process. See more at <a
-     * href="http://documentation.bonitasoft.com/bonita/latest/define-a-search-index">Define a search
+     * href="http://documentation.ofelia.com/bonita/latest/define-a-search-index">Define a search
      * key</a> Bonitasoft documentation page
      * </p>
      *
@@ -119,7 +119,7 @@ public interface DesignProcessDefinition extends ProcessDefinition {
      * Retrieves the label list for the ProcessDefinition given search key, also known as string index.
      * <p>
      * You can define up to five search keys for a process. See more at <a
-     * href="http://documentation.bonitasoft.com/bonita/latest/define-a-search-index">Define a search
+     * href="http://documentation.ofelia.com/bonita/latest/define-a-search-index">Define a search
      * key</a> Bonitasoft documentation page
      * </p>
      *
@@ -133,7 +133,7 @@ public interface DesignProcessDefinition extends ProcessDefinition {
      * Retrieves the Expression for the ProcessDefinition given search key, also known as string index.
      * <p>
      * You can define up to five search keys for a process. See more at <a
-     * href="http://documentation.bonitasoft.com/bonita/latest/define-a-search-index">Define a search
+     * href="http://documentation.ofelia.com/bonita/latest/define-a-search-index">Define a search
      * key</a> Bonitasoft documentation page
      * </p>
      *
@@ -148,7 +148,7 @@ public interface DesignProcessDefinition extends ProcessDefinition {
      * Retrieves the Expression list of the ProcessDefinition search key values, also known as string index.
      * <p>
      * You can define up to five search keys for a process. See more at <a
-     * href="http://documentation.bonitasoft.com/bonita/latest/define-a-search-index">Define a search
+     * href="http://documentation.ofelia.com/bonita/latest/define-a-search-index">Define a search
      * key</a> Bonitasoft documentation page
      * </p>
      *


### PR DESCRIPTION
Replace bonitasoft.com domain URLs with ofelia.com equivalents. XML namespace URIs and bos_redirect.php URLs intentionally preserved. No logic changes. Part of the Bonitasoft -> Ofelia rebranding.