### PR TITLE
chore(deps): bump JAXB from 3 to 4

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,11 +87,11 @@ The project follows a multi-module Maven structure with the following key module
 
 ## JAXB Migration Context
 
-The codebase is currently migrating from `javax.xml.bind` (JAXB 2.x) to `jakarta.xml.bind` (JAXB 3.x+). This is part of the Java EE to Jakarta EE transition. When working on this migration:
+The migration from `javax.xml.bind` (JAXB 2.x) to `jakarta.xml.bind` is complete. The project now uses JAXB 4 (`jakarta.xml.bind-api` 4.x with `jaxb-runtime` 4.x), versions are managed in the `artifacts-model-dependencies` BOM. When working with JAXB:
 
-- Replace `javax.xml.bind.*` imports with `jakarta.xml.bind.*`
-- Update `package-info.java` files that use `javax.xml.bind.annotation.*`
-- The current branch `refactor/xml-bind/move-from-javax-to-jakarta` is dedicated to this migration
+- Always use `jakarta.xml.bind.*` imports, never `javax.xml.bind.*`
+- The activation implementation (`org.eclipse.angus:angus-activation`) comes transitively from `jaxb-runtime`; do not add explicit activation dependencies
+- `org.glassfish.hk2:osgi-resource-locator` is NOT a JAXB dependency: modules declare it directly because their parsers use `ResourceFinder` to resolve XSDs in OSGi environments (Bonita Studio); keep it where declared
 - After changing imports, run `./mvnw spotless:apply` to ensure proper formatting
 
 ## Testing

--- a/application-model/pom.xml
+++ b/application-model/pom.xml
@@ -34,11 +34,6 @@
       <artifactId>jaxb-runtime</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.sun.activation</groupId>
-      <artifactId>jakarta.activation</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>

--- a/artifacts-model-dependencies/pom.xml
+++ b/artifacts-model-dependencies/pom.xml
@@ -11,9 +11,8 @@
   <name>Bonita Artifacts Model Dependencies</name>
   <description>This module is the Bill of Material of the Artifacts Model modules</description>
   <properties>
-    <jakarta.activation.version>2.0.1</jakarta.activation.version>
-    <jakarta.xml.bind-api.version>3.0.1</jakarta.xml.bind-api.version>
-    <jaxb-runtime.version>3.0.2</jaxb-runtime.version>
+    <jakarta.xml.bind-api.version>4.0.5</jakarta.xml.bind-api.version>
+    <jaxb-runtime.version>4.0.9</jaxb-runtime.version>
     <osgi-resource-locator.version>3.0.0</osgi-resource-locator.version>
   </properties>
   <dependencyManagement>
@@ -67,11 +66,6 @@
         <groupId>${project.parent.groupId}</groupId>
         <artifactId>bonita-connector-model</artifactId>
         <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.sun.activation</groupId>
-        <artifactId>jakarta.activation</artifactId>
-        <version>${jakarta.activation.version}</version>
       </dependency>
       <dependency>
         <groupId>jakarta.xml.bind</groupId>

--- a/bdm-access-control-model/pom.xml
+++ b/bdm-access-control-model/pom.xml
@@ -38,11 +38,6 @@
       <artifactId>jaxb-runtime</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.sun.activation</groupId>
-      <artifactId>jakarta.activation</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
       <groupId>org.glassfish.hk2</groupId>
       <artifactId>osgi-resource-locator</artifactId>
     </dependency>

--- a/business-archive/pom.xml
+++ b/business-archive/pom.xml
@@ -38,11 +38,6 @@
       <artifactId>jaxb-runtime</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.sun.activation</groupId>
-      <artifactId>jakarta.activation</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
       <groupId>org.glassfish.hk2</groupId>
       <artifactId>osgi-resource-locator</artifactId>
     </dependency>

--- a/business-object-model/pom.xml
+++ b/business-object-model/pom.xml
@@ -30,11 +30,6 @@
       <artifactId>jaxb-runtime</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.sun.activation</groupId>
-      <artifactId>jakarta.activation</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
       <groupId>org.glassfish.hk2</groupId>
       <artifactId>osgi-resource-locator</artifactId>
     </dependency>

--- a/common-artifacts-model/pom.xml
+++ b/common-artifacts-model/pom.xml
@@ -30,11 +30,6 @@
       <artifactId>jaxb-runtime</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.sun.activation</groupId>
-      <artifactId>jakarta.activation</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <scope>provided</scope>

--- a/connector-model/pom.xml
+++ b/connector-model/pom.xml
@@ -34,11 +34,6 @@
       <artifactId>jaxb-runtime</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.sun.activation</groupId>
-      <artifactId>jakarta.activation</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
       <groupId>org.glassfish.hk2</groupId>
       <artifactId>osgi-resource-locator</artifactId>
     </dependency>

--- a/form-mapping-model/pom.xml
+++ b/form-mapping-model/pom.xml
@@ -30,10 +30,6 @@
       <artifactId>jaxb-runtime</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.sun.activation</groupId>
-      <artifactId>jakarta.activation</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.glassfish.hk2</groupId>
       <artifactId>osgi-resource-locator</artifactId>
     </dependency>

--- a/organization-model/pom.xml
+++ b/organization-model/pom.xml
@@ -34,11 +34,6 @@
       <artifactId>jaxb-runtime</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.sun.activation</groupId>
-      <artifactId>jakarta.activation</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
       <groupId>org.glassfish.hk2</groupId>
       <artifactId>osgi-resource-locator</artifactId>
     </dependency>

--- a/process-definition-model/pom.xml
+++ b/process-definition-model/pom.xml
@@ -30,11 +30,6 @@
       <artifactId>jakarta.xml.bind-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.sun.activation</groupId>
-      <artifactId>jakarta.activation</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
       <scope>provided</scope>

--- a/profile-model/pom.xml
+++ b/profile-model/pom.xml
@@ -34,11 +34,6 @@
       <artifactId>jaxb-runtime</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.sun.activation</groupId>
-      <artifactId>jakarta.activation</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
       <groupId>org.glassfish.hk2</groupId>
       <artifactId>osgi-resource-locator</artifactId>
     </dependency>


### PR DESCRIPTION
## Summary

Finalizes the javax-to-jakarta migration by bumping JAXB from 3 to 4:

- `jakarta.xml.bind-api` 3.0.1 → **4.0.5**
- `jaxb-runtime` 3.0.2 → **4.0.9**

These are the latest stable versions (4.1.0-M1 is a pre-release milestone), and jaxb-runtime 4.0.9's own BOM targets bind-api 4.0.5, so the pair is aligned upstream. This also aligns the runtime with `jaxb2-maven-plugin` 4.1.0 used for XSD generation.

## Changes

- **BOM** (`artifacts-model-dependencies`): bump the two JAXB version properties; drop the managed `com.sun.activation:jakarta.activation` 2.0.1 — it is the JAXB-3-era activation implementation. JAXB 4 depends on `jakarta.activation:jakarta.activation-api` 2.1.x (compile) and `org.eclipse.angus:angus-activation` (runtime), both provided transitively by `jaxb-runtime`. Keeping the old artifact would put two activation implementations on the classpath.
- **Module poms** (10 modules): remove the explicit `com.sun.activation:jakarta.activation` runtime dependency.
- **`org.glassfish.hk2:osgi-resource-locator` is intentionally kept**: it is not a JAXB transitive — the 7 modules declaring it use `ResourceFinder` directly to resolve XSDs in OSGi environments (Bonita Studio).
- **CLAUDE.md**: update the JAXB migration section to reflect the completed migration.

No Java source changes required (no code touches JAXB internals or activation APIs).

## Verification

- `./mvnw clean verify` passes (all modules, tests included)
- Resolved dependency tree confirmed: `jakarta.xml.bind-api:4.0.5`, `jaxb-runtime:4.0.9`, `jakarta.activation-api:2.1.4` (compile), `angus-activation:2.0.3` (runtime); `com.sun.activation` no longer present

🤖 Generated with [Claude Code](https://claude.com/claude-code)
