### PR TITLE
ci(workflows): add Claude Code and Claude Code Review workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,110 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [ opened, labeled ]
+  issue_comment:
+    types: [ created ]
+
+jobs:
+  claude-review:
+    # Only run when:
+    # 1. PR is created
+    # 2. Comment on PR contains "@claude review"
+    # 3. Label "ask-claude-review" is added to PR
+    if: |
+      (
+        (github.event_name == 'pull_request' && github.event.action == 'opened') ||
+        (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '@claude review')) ||
+        (github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'ask-claude-review')
+      ) && github.actor != 'dependabot[bot]'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Get PR number
+        id: pr-number
+        run: |
+          if [ "${{ github.event_name }}" == "issue_comment" ]; then
+            echo "pr_number=${{ github.event.issue.number }}" >> $GITHUB_OUTPUT
+          else
+            echo "pr_number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1.0.183
+        with:
+          anthropic_api_key: ${{ secrets.ORGANIZATION_ANTHROPIC_API_KEY }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ steps.pr-number.outputs.pr_number }}
+
+            Please review this pull request and provide feedback on:
+            - Code quality and best practices
+            - Potential bugs or issues
+            - Performance considerations
+            - Security concerns
+            - Test coverage
+
+            Use the repository's CLAUDE.md for guidance on style and conventions. Be constructive and helpful in your feedback.
+
+            ## FORMATTING RULE — MANDATORY (read before drafting)
+
+            GitHub auto-links bare `#N` to PRs/issues and bare `@name` to user mentions.
+            Your review references review-point numbers and code symbols, NOT real PRs/users —
+            so they MUST be wrapped in backticks to render as inline code instead of links.
+
+            WRONG: "Applied #2, #4, and #5. Use @ToString on the entity."
+            RIGHT: "Applied `#2`, `#4`, and `#5`. Use `@ToString` on the entity."
+
+            Exceptions — keep plain (no backticks):
+            - Real PR/issue references: "Fixes #1234" → leave as link.
+            - Real user mentions: "cc @akantcheff" → leave as mention.
+
+            FINAL SCAN before posting: re-read your draft, find every bare "#<digits>"
+            and every "@<word>" that is not intentionally a real user mention, and
+            wrap them in backticks. Do this even on text you generated earlier in
+            the draft — the auto-linker doesn't care which paragraph it's in.
+
+            ## POSTING THE REVIEW
+
+            Update an existing Claude review comment if present, otherwise create one.
+
+            Step 1 — Find existing Claude review comment (REQUIRED):
+            COMMENT_ID=$(gh pr view ${{ steps.pr-number.outputs.pr_number }} --json comments --jq '.comments[] | select(.body | contains("## Claude Code Review")) | .id' | head -1)
+
+            Step 2 — Build the markdown body:
+            - Start with "## Claude Code Review" header (REQUIRED for identification).
+            - Add timestamp: "**Last updated:** $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
+            - Include review counter if updating: "**Review iteration:** `#N`"  (note backticks — see formatting rule)
+            - Then provide your detailed review.
+
+            Step 3 — ALWAYS update existing comment if it exists (MANDATORY):
+            if [ -n "$COMMENT_ID" ]; then
+              gh pr comment ${{ steps.pr-number.outputs.pr_number }} --edit-last --body "<your-review-markdown>"
+              echo "✓ Updated existing review comment ID: $COMMENT_ID"
+            else
+              gh pr comment ${{ steps.pr-number.outputs.pr_number }} --body "<your-review-markdown>"
+              echo "✓ Created initial review comment"
+            fi
+
+            ## REMINDERS
+
+            1. NEVER create a new "## Claude Code Review" comment if one exists — always edit the existing one.
+            2. Always start with "## Claude Code Review" for identification.
+            3. Include timestamp to show when the review was last updated.
+            4. Final formatting check: re-scan the draft for bare "#<digits>" or non-mention "@<word>" and wrap them in backticks before posting.
+
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
+          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,49 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1.0.183
+        with:
+          anthropic_api_key: ${{ secrets.ORGANIZATION_ANTHROPIC_API_KEY }}
+
+          # This is an optional setting that allows Claude to read CI results on PRs
+          additional_permissions: |
+            actions: read
+
+          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
+          # prompt: 'Update the pull request description to include a summary of changes.'
+
+          # Optional: Add claude_args to customize behavior and configuration
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
+          # claude_args: '--allowed-tools Bash(gh pr:*)'


### PR DESCRIPTION
Adds the two Claude Code GitHub Actions workflows, aligned with the ones already in use in `bonita-engine-sp`.

## Workflows

**`.github/workflows/claude.yml`** — responds to `@claude` mentions in issues, issue/PR comments, PR review comments and PR reviews.

**`.github/workflows/claude-code-review.yml`** — reviews a pull request when:
- the PR is opened,
- a comment contains `@claude review`, or
- the `ask-claude-review` label is added.

Dependabot PRs are excluded. The review is posted as a single comment that gets edited in place on subsequent runs rather than piling up new comments.

## Differences from the bonita-engine-sp reference

The `paths-ignore` block was dropped from `claude-code-review.yml`. It only listed Crowdin translation files (`**/i18n/*.po`), which do not exist in this repository.

Everything else is verbatim, including the pinned action versions.

## Verification

- Both files parse as valid YAML.
- `anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b` was confirmed to be `v1.0.183`: the annotated tag object `672170b` dereferences to that commit.
- `actions/checkout@3d3c42e` and `runs-on: ubuntu-24.04` match the existing workflows in this repository.

## Prerequisites

- The `ask-claude-review` label has been created in this repository.
- `secrets.ORGANIZATION_ANTHROPIC_API_KEY` is an organization secret. If its repository access is restricted to selected repositories, `bonita-artifacts-model` needs to be added to that list — this could not be verified without org admin rights.

## Note on versions

The action is pinned to `v1.0.183` to stay in sync with `bonita-engine-sp`. Newer patch releases exist; both repositories should be bumped together rather than letting this one drift ahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
