### PR TITLE
chore(deps): import jaxb-bom and mark superseded JAXB migration docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,9 +87,10 @@ The project follows a multi-module Maven structure with the following key module
 
 ## JAXB Migration Context
 
-The migration from `javax.xml.bind` (JAXB 2.x) to `jakarta.xml.bind` is complete. The project now uses JAXB 4 (`jakarta.xml.bind-api` 4.x with `jaxb-runtime` 4.x), versions are managed in the `artifacts-model-dependencies` BOM. When working with JAXB:
+The migration from `javax.xml.bind` (JAXB 2.x) to `jakarta.xml.bind` is complete. The project now uses JAXB 4, managed by importing `org.glassfish.jaxb:jaxb-bom` in the `artifacts-model-dependencies` BOM. When working with JAXB:
 
 - Always use `jakarta.xml.bind.*` imports, never `javax.xml.bind.*`
+- To upgrade JAXB, bump the single `jaxb-bom.version` property in `artifacts-model-dependencies/pom.xml`. Never pin `jakarta.xml.bind-api` or `jaxb-runtime` individually — the whole point of the BOM import is that the API and runtime cannot drift apart
 - The activation implementation (`org.eclipse.angus:angus-activation`) comes transitively from `jaxb-runtime`; do not add explicit activation dependencies
 - `org.glassfish.hk2:osgi-resource-locator` is NOT a JAXB dependency: modules declare it directly because their parsers use `ResourceFinder` to resolve XSDs in OSGi environments (Bonita Studio); keep it where declared
 - After changing imports, run `./mvnw spotless:apply` to ensure proper formatting
@@ -162,4 +163,4 @@ If you modify a model class and need to regenerate its AssertJ assertion class:
 
 - If tests fail with XML parsing errors, ensure XSD schemas are generated: run `./mvnw clean compile` first
 - If spotless check fails, run `./mvnw spotless:apply` to auto-format
-- If you see JAXB class loading issues, check that both `jaxb-api` and `jaxb-runtime` dependencies are present with proper exclusions for `javax.activation`
+- If you see JAXB class loading issues, check that `jakarta.xml.bind-api` and `jaxb-runtime` are both resolved; no `javax.xml.bind` or `com.sun.activation` artifacts should be on the classpath

--- a/artifacts-model-dependencies/pom.xml
+++ b/artifacts-model-dependencies/pom.xml
@@ -11,8 +11,7 @@
   <name>Bonita Artifacts Model Dependencies</name>
   <description>This module is the Bill of Material of the Artifacts Model modules</description>
   <properties>
-    <jakarta.xml.bind-api.version>4.0.5</jakarta.xml.bind-api.version>
-    <jaxb-runtime.version>4.0.9</jaxb-runtime.version>
+    <jaxb-bom.version>4.0.9</jaxb-bom.version>
     <osgi-resource-locator.version>3.0.0</osgi-resource-locator.version>
   </properties>
   <dependencyManagement>
@@ -67,15 +66,16 @@
         <artifactId>bonita-connector-model</artifactId>
         <version>${project.version}</version>
       </dependency>
-      <dependency>
-        <groupId>jakarta.xml.bind</groupId>
-        <artifactId>jakarta.xml.bind-api</artifactId>
-        <version>${jakarta.xml.bind-api.version}</version>
-      </dependency>
+      <!-- Import jaxb-bom instead of pinning jakarta.xml.bind-api and jaxb-runtime individually:
+           it keeps the JAXB API and runtime aligned by construction, and its single coordinate
+           matches the "*jaxb*" Dependabot group pattern (unlike jakarta.xml.bind:jakarta.xml.bind-api),
+           so both are bumped together in one PR. -->
       <dependency>
         <groupId>org.glassfish.jaxb</groupId>
-        <artifactId>jaxb-runtime</artifactId>
-        <version>${jaxb-runtime.version}</version>
+        <artifactId>jaxb-bom</artifactId>
+        <version>${jaxb-bom.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>org.glassfish.hk2</groupId>

--- a/doc/adr/javax-to-jakarta-migration-plan.md
+++ b/doc/adr/javax-to-jakarta-migration-plan.md
@@ -1,7 +1,9 @@
 # Architecture Decision Record: javax to jakarta XML Binding Migration
 
 ## Status
-✅ Completed
+✅ Completed — superseded (see note below)
+
+> **Note (2026-08, superseded by the JAXB 4 bump, PR #232):** the JAXB 3 details below are historical. The project now uses JAXB 4, managed via the `org.glassfish.jaxb:jaxb-bom` import in `artifacts-model-dependencies`. In particular, `com.sun.activation:jakarta.activation` is no longer used: the activation implementation is `org.eclipse.angus:angus-activation`, provided transitively by `jaxb-runtime`. Do not re-add dependencies based on this document.
 
 ## Decisions Made
 

--- a/docs/001-migration-to-jakarta_dependency-comparison.md
+++ b/docs/001-migration-to-jakarta_dependency-comparison.md
@@ -1,5 +1,7 @@
 # Dependency Tree Comparison: javax.xml.bind → jakarta.xml.bind Migration
 
+> **Note (2026-08, superseded by the JAXB 4 bump, PR #232):** this comparison documents the JAXB 2 → 3 migration and is kept as a historical record. The project has since moved to JAXB 4: `com.sun.activation:jakarta.activation` was removed in favor of `jakarta.activation-api` + `org.eclipse.angus:angus-activation` (transitive from `jaxb-runtime`).
+
 ## Module: bonita-business-archive
 
 ### BEFORE Migration (commit 3315bcb)


### PR DESCRIPTION
## Summary

Follow-ups from the code review of #232 (JAXB 3 → 4 bump), covering review findings `#1`, `#4` and `#7`.

## Changes

- **Import `org.glassfish.jaxb:jaxb-bom` 4.0.9** in the `artifacts-model-dependencies` BOM instead of managing `jakarta.xml.bind-api` and `jaxb-runtime` versions independently. This makes API/runtime drift (the exact problem #232 fixed) structurally impossible: jaxb-bom keeps `jakarta.xml.bind-api`, `jaxb-runtime`, `jaxb-core`, `txw2` and the activation artifacts consistent by construction. The resolved versions are unchanged — jaxb-bom 4.0.9 pins `jakarta.xml.bind-api` at 4.0.5, exactly what was already chosen.
  - This also fixes the tooling mechanism behind the drift: the Dependabot `jaxb` group pattern `*jaxb*` matches `jaxb-bom` but never matched `jakarta.xml.bind:jakarta.xml.bind-api`, so API and runtime bumps used to arrive as separate PRs. With a single managed coordinate, they are bumped together in one PR.
  - **Consumer-visible note**: the published (flattened) BOM keeps the literal `jaxb-bom` import, so projects importing `bonita-artifacts-model-dependencies` now inherit jaxb-bom's full managed set (`jaxb-core`, `txw2`, `istack-commons-runtime`, `jakarta.activation-api`, `angus-activation`) instead of only the two previous coordinates. The pinned versions are exactly what `jaxb-runtime` 4.0.9 requires, and consumers' own dependencyManagement/constraints still take precedence (Maven local management beats an imported BOM; Gradle `platform()` constraints don't force downgrades), so no movement is expected — flagging it for awareness.
- **Fix the stale JAXB guidance in CLAUDE.md**: the "Common Issues" entry still referenced `jaxb-api` and `javax.activation` exclusions, and the "JAXB Migration Context" section now documents the bom-import invariant (bump the single `jaxb-bom.version` property; never pin `jakarta.xml.bind-api` or `jaxb-runtime` individually).
- **Mark the historical javax-to-jakarta migration docs as superseded** (`doc/adr/javax-to-jakarta-migration-plan.md` — including its Status line — and `docs/001-migration-to-jakarta_dependency-comparison.md`): they still instruct to keep `com.sun.activation:jakarta.activation`, which #232 removed — a note now prevents anyone from re-adding it based on those documents.

## Verification

- `./mvnw clean verify` passes with the jaxb-bom import
- Resolved dependency tree is identical to #232: `jakarta.xml.bind-api:4.0.5`, `jaxb-runtime:4.0.9`, `jakarta.activation-api:2.1.4` (compile), `angus-activation:2.0.3` (runtime)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
